### PR TITLE
upgrade to wala/WALA latest version

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/resources/dataflow.py
+++ b/com.ibm.wala.cast.python.ml.test/resources/dataflow.py
@@ -1,0 +1,7 @@
+import numpy as np
+def get_punctuation_mark(sentence):
+    cc=0
+    for word in sentence:
+        cc = np.sum(word)
+
+    return cc

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestMNISTExamples.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestMNISTExamples.java
@@ -1,8 +1,18 @@
 package com.ibm.wala.cast.python.ml.test;
 
 import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 
+import com.ibm.wala.cast.loader.AstMethod;
+import com.ibm.wala.cast.python.client.PythonAnalysisEngine;
+import com.ibm.wala.cast.python.client.PythonTurtleAnalysisEngine;
+import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
+import com.ibm.wala.ipa.callgraph.propagation.*;
+import com.ibm.wala.ssa.*;
+import com.ibm.wala.util.collections.HashMapFactory;
+import com.ibm.wala.util.graph.Graph;
 import org.junit.Test;
 
 import com.ibm.wala.cast.ipa.callgraph.CAstCallGraphUtil;
@@ -16,20 +26,12 @@ import com.ibm.wala.cast.types.AstMethodReference;
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
-import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
-import com.ibm.wala.ipa.callgraph.propagation.PointerKeyFactory;
-import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
-import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
-import com.ibm.wala.ipa.callgraph.propagation.PropagationSystem;
-import com.ibm.wala.ipa.callgraph.propagation.SSAContextInterpreter;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
-import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
-import com.ibm.wala.ssa.SSAInstruction;
-import com.ibm.wala.ssa.SSAReturnInstruction;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.collections.HashSetFactory;
+import org.python.modules._codecs$utf_7_decode_exposer;
 
 public class TestMNISTExamples extends TestPythonMLCallGraphShape {
 
@@ -184,5 +186,53 @@ public class TestMNISTExamples extends TestPythonMLCallGraphShape {
 			}
 			assert goodFeeds.size() > 0;
 		});
+	}
+
+	@Test
+	public void testDataFlow() throws ClassHierarchyException, IOException, CancelException {
+
+
+
+		PythonAnalysisEngine<?> E = makeEngine("/Users/malinda/Documents/Research3/wala_ml/com.ibm.wala.cast.python.ml.test/resources/dataflow.py");
+		PythonSSAPropagationCallGraphBuilder B = E.defaultCallGraphBuilder();
+		CallGraph CG = B.makeCallGraph(B.getOptions());
+
+		CAstCallGraphUtil.AVOID_DUMP = false;
+//		CAstCallGraphUtil.dumpCG((SSAContextInterpreter)B.getContextInterpreter(), B.getPointerAnalysis(), CG);
+//		System.out.println(CG.toString());
+		for (CGNode cgnode : CG) {
+//			if (cgnode.getMethod() instanceof AstMethod) {
+				IR callerIR = cgnode.getIR();
+				DefUse DU = cgnode.getDU();
+				SSAInstruction[] instructions = callerIR.getInstructions();
+				if (instructions.length>0){
+				for (int i = 0; i < instructions.length; i++) {
+					try {
+						int def1 = instructions[i].getDef();
+						System.out.println(instructions[i].toString());
+						Iterator<SSAInstruction> uses = DU.getUses(def1);
+						for (Iterator<SSAInstruction> it = uses; it.hasNext(); ) {
+							SSAInstruction item = it.next();
+							System.out.println("uses"+item.toString());
+						}
+					}
+					catch (AssertionError|ArrayIndexOutOfBoundsException|NullPointerException e){
+
+					}
+
+				}
+//					SSAInstruction def = DU.getDef(i);
+//					for (int j = 0; j < def.getNumberOfUses(); j++) {
+//						int use = def.getU(j);
+//					}
+
+
+
+				}
+
+//				System.out.println("DU");
+//			}
+		}
+
 	}
 }

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonAnalysisEngine.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonAnalysisEngine.java
@@ -279,9 +279,9 @@ public abstract class PythonAnalysisEngine<T>
 		addSummaryBypassLogic(options, "functools.xml");
 	}
 
-	
+
 	@Override
-	protected Iterable<Entrypoint> makeDefaultEntrypoints(AnalysisScope scope, IClassHierarchy cha) {
+	protected Iterable<Entrypoint> makeDefaultEntrypoints(IClassHierarchy cha) {
 		Set<Entrypoint> result = HashSetFactory.make();
 		cha.forEach(entry -> {
 			if (entry.getName().toString().endsWith(".py")) {

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonTurtleLibraryAnalysisEngine.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonTurtleLibraryAnalysisEngine.java
@@ -8,7 +8,7 @@ import com.ibm.wala.ipa.cha.IClassHierarchy;
 public class PythonTurtleLibraryAnalysisEngine extends PythonTurtleAnalysisEngine {
 
 	@Override
-	protected Iterable<Entrypoint> makeDefaultEntrypoints(AnalysisScope scope, IClassHierarchy cha) {
+	protected Iterable<Entrypoint> makeDefaultEntrypoints(IClassHierarchy cha) {
 		return TurtleSummary.turtleEntryPoints(cha);
 	}
 


### PR DESCRIPTION
The method signature of `AbstractAnalysisEngine::makeDefaultEntrypoints(AnalysisScope scope, IClassHierarchy cha)` has been updated to `AbstractAnalysisEngine::makeDefaultEntrypoints(IClassHierarchy cha)` in wala/WALA. 

https://github.com/wala/WALA/commit/156d3266a974baabd22314f959604b10cc8eb339#diff-9968ab3793577fbdbb2bcac521273e2c37f756faa5484d519c0e07a159385393R265