### PR TITLE
Split JARs, one for libraries and the other for execution

### DIFF
--- a/com.ibm.wala.cast.python.ml/pom.xml
+++ b/com.ibm.wala.cast.python.ml/pom.xml
@@ -94,6 +94,7 @@
                 <mainClass>com.ibm.wala.cast.python.ml.driver.Ariadne</mainClass>
                 </transformer>
               </transformers>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
             </configuration>
           </execution>
         </executions>

--- a/com.ibm.wala.cast.python.ml/run.sh
+++ b/com.ibm.wala.cast.python.ml/run.sh
@@ -3,4 +3,4 @@
 ME=`realpath $0`
 DIR=`dirname $ME`
 
-cat -u | tee -a /tmp/lsp.in.log | $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,address=127.0.0.1:6660,server=y,suspend=n -jar $DIR/target/com.ibm.wala.cast.python.ml-0.0.1-SNAPSHOT.jar --mode stdio | tee -a /tmp/lsp.out.log
+cat -u | tee -a /tmp/lsp.in.log | $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,address=127.0.0.1:6660,server=y,suspend=n -jar $DIR/target/com.ibm.wala.cast.python.ml-0.0.1-SNAPSHOT-shaded.jar --mode stdio | tee -a /tmp/lsp.out.log


### PR DESCRIPTION
Address https://github.com/wala/ML/issues/28. See https://maven.apache.org/plugins/maven-shade-plugin/examples/attached-artifact.html for reference.