### PR TITLE
Metadata, build script, and warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
  - mvn clean install -B -q -DskipTests
  - popd
 script:
- - mvn clean install -B
+ - mvn clean verify -B
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/com.ibm.wala.cast.python.jython.test/.classpath
+++ b/com.ibm.wala.cast.python.jython.test/.classpath
@@ -12,15 +12,9 @@
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="test-source">
 		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
 			<attribute name="test" value="true"/>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/classes" path="src/main/java">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/com.ibm.wala.cast.python.jython.test/.classpath
+++ b/com.ibm.wala.cast.python.jython.test/.classpath
@@ -12,9 +12,9 @@
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="test-source">
 		<attributes>
+			<attribute name="test" value="true"/>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" output="target/classes" path="src/main/java">

--- a/com.ibm.wala.cast.python.jython.test/META-INF/MANIFEST.MF
+++ b/com.ibm.wala.cast.python.jython.test/META-INF/MANIFEST.MF
@@ -6,11 +6,5 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: IBM
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.ibm.wala.cast.python;bundle-version="0.0.1",
- com.ibm.wala.cast.test;bundle-version="1.4.4",
- com.ibm.wala.core.tests,
- com.ibm.wala.cast,
- com.ibm.wala.core,
- com.ibm.wala.util,
- com.ibm.wala.shrike,
  org.junit;bundle-version="4.12.0"
 Automatic-Module-Name: com.ibm.wala.cast.python.test

--- a/com.ibm.wala.cast.python.jython.test/META-INF/MANIFEST.MF
+++ b/com.ibm.wala.cast.python.jython.test/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: WALA CAst Python Tests
 Bundle-SymbolicName: com.ibm.wala.cast.python.test
 Bundle-Version: 1.0.0.qualifier
+Export-Package: com.ibm.wala.cast.python.jython.test
 Bundle-Vendor: IBM
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.ibm.wala.cast.python;bundle-version="0.0.1",

--- a/com.ibm.wala.cast.python.jython.test/build.properties
+++ b/com.ibm.wala.cast.python.jython.test/build.properties
@@ -1,4 +1,3 @@
-source.. = source/,\
-           data/
+source.. = test-source/
 bin.includes = META-INF/,\
                .

--- a/com.ibm.wala.cast.python.jython.test/pom.xml
+++ b/com.ibm.wala.cast.python.jython.test/pom.xml
@@ -48,6 +48,7 @@
     </dependency>
   </dependencies>
   <build>
+    <sourceDirectory>test-source</sourceDirectory>
     <testSourceDirectory>test-source</testSourceDirectory>
     <plugins>
       <plugin>

--- a/com.ibm.wala.cast.python.jython3.test/.classpath
+++ b/com.ibm.wala.cast.python.jython3.test/.classpath
@@ -17,11 +17,5 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="target/classes" path="src/main/java">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/com.ibm.wala.cast.python.jython3.test/META-INF/MANIFEST.MF
+++ b/com.ibm.wala.cast.python.jython3.test/META-INF/MANIFEST.MF
@@ -6,11 +6,5 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: IBM
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.ibm.wala.cast.python;bundle-version="0.0.1",
- com.ibm.wala.cast.test,
- com.ibm.wala.core.tests,
- com.ibm.wala.cast,
- com.ibm.wala.core,
- com.ibm.wala.util,
- com.ibm.wala.shrike,
  org.junit;bundle-version="4.12.0"
 Automatic-Module-Name: com.ibm.wala.cast.python.test

--- a/com.ibm.wala.cast.python.jython3.test/META-INF/MANIFEST.MF
+++ b/com.ibm.wala.cast.python.jython3.test/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: WALA CAst Python Tests
 Bundle-SymbolicName: com.ibm.wala.cast.python.test
 Bundle-Version: 1.0.0.qualifier
+Export-Package: com.ibm.wala.cast.python.jython3.test
 Bundle-Vendor: IBM
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.ibm.wala.cast.python;bundle-version="0.0.1",

--- a/com.ibm.wala.cast.python.jython3.test/build.properties
+++ b/com.ibm.wala.cast.python.jython3.test/build.properties
@@ -1,4 +1,3 @@
-source.. = source/,\
-           data/
+source.. = test-source/,
 bin.includes = META-INF/,\
                .

--- a/com.ibm.wala.cast.python.jython3.test/pom.xml
+++ b/com.ibm.wala.cast.python.jython3.test/pom.xml
@@ -56,6 +56,7 @@
     </dependency>
   </dependencies>
   <build>
+    <sourceDirectory>test-source</sourceDirectory>
     <testSourceDirectory>test-source</testSourceDirectory>
     <plugins>
       <plugin>

--- a/com.ibm.wala.cast.python.jython3/META-INF/MANIFEST.MF
+++ b/com.ibm.wala.cast.python.jython3/META-INF/MANIFEST.MF
@@ -5,13 +5,4 @@ Bundle-SymbolicName: com.ibm.wala.cast.python
 Bundle-Version: 0.0.1.qualifier
 Bundle-Vendor: IBM
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: com.ibm.wala.cast;bundle-version="1.4.4",
- com.ibm.wala.core;bundle-version="1.4.4",
- com.ibm.wala.util;bundle-version="1.4.4",
- com.ibm.wala.shrike;bundle-version="1.4.4",
- com.ibm.wala.cast.java,
- com.ibm.wala.cast.lsp;bundle-version="0.0.1",
- com.google.gson;bundle-version="2.7.0"
 Automatic-Module-Name: com.ibm.wala.cast.python
-Import-Package: org.apache.commons.lang.mutable,
- org.apache.commons.lang3.mutable

--- a/com.ibm.wala.cast.python.jython3/META-INF/MANIFEST.MF
+++ b/com.ibm.wala.cast.python.jython3/META-INF/MANIFEST.MF
@@ -3,6 +3,12 @@ Bundle-ManifestVersion: 2
 Bundle-Name: WALA Python
 Bundle-SymbolicName: com.ibm.wala.cast.python
 Bundle-Version: 0.0.1.qualifier
+Export-Package: com.ibm.wala.cast.python.client,
+ com.ibm.wala.cast.python.driver,
+ com.ibm.wala.cast.python.loader,
+ com.ibm.wala.cast.python.parser,
+ com.ibm.wala.cast.python.util,
+ org.python.antlr
 Bundle-Vendor: IBM
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: com.ibm.wala.cast.python

--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonModuleParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonModuleParser.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import org.antlr.runtime.ANTLRInputStream;

--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -1381,7 +1381,7 @@ abstract public class PythonParser<T> extends AbstractParser<T> implements Trans
 
 		private final boolean wholeStatement = true;
 		
-		private <T extends stmt> CAstNode importAst(T importNode, java.util.List<Name> names ) {
+		private <T1 extends stmt> CAstNode importAst(T1 importNode, java.util.List<Name> names ) {
 			CAstNode importAst = notePosition(Ast.makeNode(CAstNode.PRIMITIVE, 
 				Ast.makeConstant("import"), 
 				Ast.makeConstant(names.get(0).getInternalId())), wholeStatement? importNode: names.get(0));

--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/util/Python3Interpreter.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/util/Python3Interpreter.java
@@ -1,7 +1,5 @@
 package com.ibm.wala.cast.python.util;
 
-import org.python.core.PyObject;
-import org.python.core.PySystemState;
 import org.python.util.PythonInterpreter;
 
 public class Python3Interpreter extends com.ibm.wala.cast.python.util.PythonInterpreter {

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -6,13 +6,11 @@ import java.util.Iterator;
 
 import org.junit.Test;
 
-import com.ibm.wala.cast.ipa.callgraph.CAstCallGraphUtil;
 import com.ibm.wala.cast.python.client.PythonAnalysisEngine;
 import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
 import com.ibm.wala.cast.python.ml.analysis.TensorTypeAnalysis;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
-import com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.util.CancelException;
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorVariable.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorVariable.java
@@ -19,8 +19,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.ibm.wala.cast.python.ml.types.TensorType;
-import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
-import com.ibm.wala.cast.python.ml.types.TensorType.Format;
 import com.ibm.wala.fixpoint.IVariable;
 import com.ibm.wala.util.collections.HashSetFactory;
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/driver/DiagnosticsFormatter.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/driver/DiagnosticsFormatter.java
@@ -22,7 +22,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import com.ibm.wala.cast.lsp.WALAServer;
 
 public class DiagnosticsFormatter {
 

--- a/com.ibm.wala.cast.python.test/META-INF/MANIFEST.MF
+++ b/com.ibm.wala.cast.python.test/META-INF/MANIFEST.MF
@@ -6,3 +6,4 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: IBM
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: com.ibm.wala.cast.python.test
+Export-Package: com.ibm.wala.cast.python.test

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestClasses.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestClasses.java
@@ -2,7 +2,6 @@ package com.ibm.wala.cast.python.test;
 
 import java.io.IOException;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.ibm.wala.cast.ipa.callgraph.CAstCallGraphUtil;

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestPythonTurtlePandaMergeCallGraphShape.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestPythonTurtlePandaMergeCallGraphShape.java
@@ -3,14 +3,12 @@ package com.ibm.wala.cast.python.test;
 import java.io.IOException;
 import java.util.Set;
 
-import com.ibm.wala.cast.ipa.callgraph.CAstCallGraphUtil;
 import com.ibm.wala.cast.python.client.PythonAnalysisEngine;
 import com.ibm.wala.cast.python.client.PythonTurtleAnalysisEngine.EdgeType;
 import com.ibm.wala.cast.python.client.PythonTurtleAnalysisEngine.TurtlePath;
 import com.ibm.wala.cast.python.client.PythonTurtlePandasMergeAnalysis;
 import com.ibm.wala.classLoader.Module;
 import com.ibm.wala.ipa.callgraph.CallGraph;
-import com.ibm.wala.ipa.callgraph.propagation.SSAContextInterpreter;
 import com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.util.CancelException;

--- a/com.ibm.wala.cast.python/META-INF/MANIFEST.MF
+++ b/com.ibm.wala.cast.python/META-INF/MANIFEST.MF
@@ -6,5 +6,3 @@ Bundle-Version: 0.0.1.qualifier
 Bundle-Vendor: IBM
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: com.ibm.wala.cast.python
-Import-Package: org.apache.commons.lang.mutable,
- org.apache.commons.lang3.mutable

--- a/com.ibm.wala.cast.python/META-INF/MANIFEST.MF
+++ b/com.ibm.wala.cast.python/META-INF/MANIFEST.MF
@@ -3,6 +3,19 @@ Bundle-ManifestVersion: 2
 Bundle-Name: WALA Python
 Bundle-SymbolicName: com.ibm.wala.cast.python
 Bundle-Version: 0.0.1.qualifier
+Export-Package: com.ibm.wala.cast.python.analysis.ap,
+ com.ibm.wala.cast.python.cfg,
+ com.ibm.wala.cast.python.client,
+ com.ibm.wala.cast.python.driver,
+ com.ibm.wala.cast.python.ipa.callgraph,
+ com.ibm.wala.cast.python.ipa.summaries,
+ com.ibm.wala.cast.python.ir,
+ com.ibm.wala.cast.python.loader,
+ com.ibm.wala.cast.python.modref,
+ com.ibm.wala.cast.python.parser,
+ com.ibm.wala.cast.python.ssa,
+ com.ibm.wala.cast.python.types,
+ com.ibm.wala.cast.python.util
 Bundle-Vendor: IBM
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: com.ibm.wala.cast.python

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonSSAPropagationCallGraphBuilder.java
@@ -27,7 +27,6 @@ import com.ibm.wala.ipa.callgraph.AnalysisOptions;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 import com.ibm.wala.ipa.callgraph.propagation.AbstractFieldPointerKey;
-import com.ibm.wala.ipa.callgraph.propagation.ConcreteTypeKey;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointerKeyFactory;

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonTrampolineTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonTrampolineTargetSelector.java
@@ -29,7 +29,6 @@ import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.ssa.SSAReturnInstruction;
 import com.ibm.wala.types.FieldReference;
 import com.ibm.wala.types.MethodReference;
-import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.core.util.strings.Atom;

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/PythonSuper.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/PythonSuper.java
@@ -36,7 +36,6 @@ import com.ibm.wala.ssa.IRView;
 import com.ibm.wala.ssa.ISSABasicBlock;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
-import com.ibm.wala.ssa.SSANewInstruction;
 import com.ibm.wala.ssa.SSAOptions;
 import com.ibm.wala.types.FieldReference;
 import com.ibm.wala.types.MethodReference;

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/TurtleSummary.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/TurtleSummary.java
@@ -1,7 +1,5 @@
 package com.ibm.wala.cast.python.ipa.summaries;
 
-import static com.ibm.wala.cast.python.ir.PythonLanguage.Python;
-
 import java.io.Reader;
 import java.util.Collection;
 import java.util.Collections;

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -37,7 +37,6 @@ import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
 import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.cast.tree.CAstEntity;
 import com.ibm.wala.cast.tree.CAstNode;
-import com.ibm.wala.cast.tree.CAstSourcePositionMap;
 import com.ibm.wala.cast.tree.CAstSourcePositionMap.Position;
 import com.ibm.wala.cast.tree.CAstType;
 import com.ibm.wala.cast.tree.impl.CAstControlFlowRecorder;

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonLanguage.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonLanguage.java
@@ -55,7 +55,6 @@ import com.ibm.wala.shrike.shrikeCT.BootstrapMethodsReader.BootstrapMethod;
 import com.ibm.wala.shrike.shrikeCT.InvalidClassFileException;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
-import com.ibm.wala.ssa.SSAInvokeInstruction;
 import com.ibm.wala.types.FieldReference;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeName;

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoaderFactory.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoaderFactory.java
@@ -12,8 +12,6 @@ package com.ibm.wala.cast.python.loader;
 
 import com.ibm.wala.cast.loader.SingleClassLoaderFactory;
 import com.ibm.wala.cast.python.types.PythonTypes;
-import com.ibm.wala.classLoader.IClassLoader;
-import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.types.ClassLoaderReference;
 
 public abstract class PythonLoaderFactory extends SingleClassLoaderFactory {


### PR DESCRIPTION
Various fixes:
1. Use `verify` instead of `install` during testing (seems to be the convention).
2. Fix metadata issue with Jython test subprojects. Warning now disappears.
3. Other metadata fixes, mostly from obsolete OSGi metadata (Maven used instead).
4. Java warning cleanup (unused imports, etc.).