### PR TITLE
Fix parameter index bug during function parsing and generalize test

### DIFF
--- a/com.ibm.wala.cast.python.jython/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -909,22 +909,21 @@ abstract public class PythonParser<T> extends AbstractParser<T> implements Trans
 			int argIndex = 0;
 			argumentNames[x++] = "the function";
 			argumentMap[argIndex++] = 0;
-			int ai = 0;
 			for(expr a : arguments) {
 				if (a instanceof Tuple) {
 					Tuple t = (Tuple)a;
 					for(expr e : t.getInternalElts()) {
 						CAstNode cast = e.accept(this);
 						String name = cast.getChild(0).getValue().toString();
-						argumentMap[x] = ai;
+						argumentMap[x] = argIndex;
 						argumentNames[x++] = name;			
 					}
 				} else {
 					String name = a.accept(this).getChild(0).getValue().toString();
-					argumentMap[x] = ai;
+					argumentMap[x] = argIndex;
 					argumentNames[x++] = name;		
 				}
-				ai++;
+				argIndex++;
 			}
 			
 			AbstractCodeEntity fun = new AbstractCodeEntity(functionType) {

--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -1111,10 +1111,9 @@ abstract public class PythonParser<T> extends AbstractParser<T> implements Trans
 			int argIndex = 0;
 			argumentNames[x++] = "the function";
 			argumentMap[argIndex++] = 0;
-			int ai = 0;
 			for(Object a : arguments) {
-				x = handleFunctionArguments(x, argumentNames, argumentMap, ai, a);
-				ai++;
+				x = handleFunctionArguments(x, argumentNames, argumentMap, argIndex, a);
+				argIndex++;
 			}
 			
 			class PythonCodeEntity extends AbstractCodeEntity implements PythonGlobalsEntity, DynamicAnnotatableEntity {

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -143,8 +143,15 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
 			Position parameterPosition = method.getParameterPosition(paramIndex);
 
 			// check the line.
-			// the function is declared on line 3. Each parameter is also declared on that line.
-			assertEquals(3, parameterPosition.getFirstLine());
+			int expectedLine;
+			if (filename.equals("tf2.py") || filename.equals("tf2b.py"))
+				expectedLine = 3;
+			else if (filename.equals("tf2c.py"))
+				expectedLine = 4;
+			else
+				throw new IllegalArgumentException("Unexpected filename: " + filename + ".");
+
+			assertEquals(expectedLine, parameterPosition.getFirstLine());
 
 			// check the columns.
 			if (lpk.getValueNumber() == 2) {

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -63,8 +63,8 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
 		testTf2("tf2c.py", "add", 2, 2, 3);
 	}
 
-	private void testTf2(String testFile, String functionName, int expectedNumberOfTensorParameters, int... expectedValueNumbers) throws ClassHierarchyException, CancelException, IOException {
-		PythonAnalysisEngine<TensorTypeAnalysis> E = makeEngine(testFile);
+	private void testTf2(String filename, String functionName, int expectedNumberOfTensorParameters, int... expectedValueNumbers) throws ClassHierarchyException, CancelException, IOException {
+		PythonAnalysisEngine<TensorTypeAnalysis> E = makeEngine(filename);
 		PythonSSAPropagationCallGraphBuilder builder = E.defaultCallGraphBuilder();
 
 		CallGraph CG = builder.makeCallGraph(builder.getOptions());
@@ -118,7 +118,7 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
 		assertEquals(expectedNumberOfTensorParameters, methodSignatureToPointerKeys.size());
 		assertEquals(expectedNumberOfTensorParameters, methodSignatureToTensorVariables.size());
 
-		final String functionSignature = "script " + testFile + "." + functionName + ".do()LRoot;";
+		final String functionSignature = "script " + filename + "." + functionName + ".do()LRoot;";
 
 		// get the pointer keys for the function.
 		Set<LocalPointerKey> functionPointerKeys = methodSignatureToPointerKeys.get(functionSignature);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -2,7 +2,6 @@ package com.ibm.wala.cast.python.ml.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -10,20 +9,17 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
 
-import com.ibm.wala.cast.loader.AstMethod;
 //import com.ibm.wala.cast.ipa.callgraph.CAstCallGraphUtil;
 import com.ibm.wala.cast.python.client.PythonAnalysisEngine;
 import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
 import com.ibm.wala.cast.python.ml.analysis.TensorTypeAnalysis;
 import com.ibm.wala.cast.python.ml.analysis.TensorVariable;
-import com.ibm.wala.cast.tree.CAstSourcePositionMap.Position;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModelParsing.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModelParsing.java
@@ -5,11 +5,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -21,7 +18,6 @@ import com.ibm.wala.cast.loader.AstMethod;
 import com.ibm.wala.cast.python.client.PythonAnalysisEngine;
 import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
 import com.ibm.wala.cast.python.ml.analysis.TensorTypeAnalysis;
-import com.ibm.wala.cast.python.ml.analysis.TensorVariable;
 import com.ibm.wala.cast.tree.CAstSourcePositionMap.Position;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -31,47 +27,15 @@ import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.util.CancelException;
 
-public class TestTensorflowModel extends TestPythonMLCallGraphShape {
+public class TestTensorflowModelParsing extends TestPythonMLCallGraphShape {
 
+	/**
+	 * Test a parsing bug (see https://github.com/wala/ML/pull/46#issue-1743032519).
+	 */
 	@Test
-	public void testTf1() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-		PythonAnalysisEngine<TensorTypeAnalysis> E = makeEngine("tf1.py");
-		PythonSSAPropagationCallGraphBuilder builder = E.defaultCallGraphBuilder();
-		CallGraph CG = builder.makeCallGraph(builder.getOptions());
-		
-//		CAstCallGraphUtil.AVOID_DUMP = false;
-//		CAstCallGraphUtil.dumpCG(((SSAPropagationCallGraphBuilder)builder).getCFAContextInterpreter(), builder.getPointerAnalysis(), CG);
-
-//		System.err.println(CG);
-		
-		Collection<CGNode> nodes = getNodes(CG, "script tf1.py/model_fn");
-		assert ! nodes.isEmpty() : "model_fn should be called";
-		check: {
-			for(CGNode node : nodes) {
-				for(Iterator<CGNode> ns = CG.getPredNodes(node); ns.hasNext(); ) {
-					if (ns.next().getMethod().isWalaSynthetic()) {
-						break check;
-					}
-				}
-			
-				assert false : node + " should have synthetic caller";
-			}
-		}
-	}
-
-	@Test
-	public void testTf2() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-		final Set<String> filesToTest = new LinkedHashSet<>();
-		filesToTest.add("tf2.py");
-		filesToTest.add("tf2b.py");
-		filesToTest.add("tf2c.py");
-
-		for (String testFile : filesToTest)
-			testTf2(testFile);
-	}
-
-	private void testTf2(String testFile) throws ClassHierarchyException, CancelException, IOException {
-		PythonAnalysisEngine<TensorTypeAnalysis> E = makeEngine(testFile);
+	public void testParsing() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+		final String filename = "parsing_test.py";
+		PythonAnalysisEngine<TensorTypeAnalysis> E = makeEngine(filename);
 		PythonSSAPropagationCallGraphBuilder builder = E.defaultCallGraphBuilder();
 
 		CallGraph CG = builder.makeCallGraph(builder.getOptions());
@@ -86,9 +50,6 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
 
 		// Create a mapping from method signatures to pointer keys.
 		Map<String, Set<LocalPointerKey>> methodSignatureToPointerKeys = new HashMap<>();
-
-		// Create a mapping from method signatures to tensor variables.
-		Map<String, Set<TensorVariable>> methodSignatureToTensorVariables = new HashMap<>();
 
 		// for each pointer key, tensor variable pair.
 		analysis.forEach(p -> {
@@ -109,23 +70,12 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
 				v.add(localPointerKey);
 				return v;
 			});
-
-			TensorVariable tensorVariable = p.snd;
-
-			// associate the method to the tensor variables.
-			methodSignatureToTensorVariables.compute(methodSignature, (k, v) -> {
-				if (v == null)
-					v = new HashSet<>();
-				v.add(tensorVariable);
-				return v;
-			});
 		});
 
 		// we should have two methods.
 		assertEquals(2, methodSignatureToPointerKeys.size());
-		assertEquals(2, methodSignatureToTensorVariables.size());
 
-		final String addFunctionSignature = "script " + testFile + ".add.do()LRoot;";
+		final String addFunctionSignature = "script " + filename + ".add.do()LRoot;";
 
 		// get the pointer keys for the add() function.
 		Set<LocalPointerKey> addFunctionPointerKeys = methodSignatureToPointerKeys.get(addFunctionSignature);
@@ -140,10 +90,24 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
 		assertTrue(valueNumberSet.contains(2));
 		assertTrue(valueNumberSet.contains(3));
 
-		// get the tensor variables for the add() function.
-		Set<TensorVariable> addFunctionTensors = methodSignatureToTensorVariables.get(addFunctionSignature);
+		// check the source positions of each function parameter.
+		for (LocalPointerKey lpk : addFunctionPointerKeys) {
+			AstMethod method = (AstMethod) lpk.getNode().getIR().getMethod();
+			int paramIndex = lpk.getValueNumber() - 1;
+			Position parameterPosition = method.getParameterPosition(paramIndex);
 
-		// two tensor parameters, a and b.
-		assertEquals(2, addFunctionTensors.size());
+			// check the line.
+			assertEquals(3, parameterPosition.getFirstLine());
+
+			// check the columns.
+			if (lpk.getValueNumber() == 2) {
+				assertEquals(8, parameterPosition.getFirstCol());
+				assertEquals(9, parameterPosition.getLastCol());
+			} else if (lpk.getValueNumber() == 3) {
+				assertEquals(11, parameterPosition.getFirstCol());
+				assertEquals(12, parameterPosition.getLastCol());
+			} else
+				throw new IllegalStateException("Expecting value numbers 2 or 3.");
+		}
 	}
 }

--- a/com.ibm.wala.cast.python.test/data/parsing_test.py
+++ b/com.ibm.wala.cast.python.test/data/parsing_test.py
@@ -1,0 +1,7 @@
+import tensorflow as tf
+
+def add(a, b):
+  return a + b
+
+
+c = add(tf.ones([1, 2]), tf.ones([2, 2]))  #  [[2., 2.], [2., 2.]]


### PR DESCRIPTION
1. The source positions are incorrect when there are multiple explicit parameters; the second one gets the same position as the first. For example, we would get A.py [4:8] -> [4:9] twice for two different parameters.
2. Make the TF2 tensor analysis tests more general to allow more flexibility in input test file structure.