### PR TITLE
More XML formatting and GH Actions fix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,15 +21,15 @@ jobs:
       with:
         repository: wala/IDE
         # fetch-depth: 50
-        path: /tmp/IDE
+        path: ./IDE
     - name: Checkout juliandolby/jython3 sources.
       uses: actions/checkout@v3.5.2
       with:
         repository: juliandolby/jython3
-        path: /tmp/jython3
+        path: ./jython3
     - name: Install Jython3.
       run: |
-        pushd /tmp/jython3
+        pushd ./jython3
         ant
         pushd dist
         mvn install:install-file -Dfile=./jython-dev.jar -DgroupId="org.python" -DartifactId="jython3" -Dversion="0.0.1-SNAPSHOT" -Dpackaging="jar" -DgeneratePom=true
@@ -38,7 +38,7 @@ jobs:
       shell: bash
     - name: Install IDE.
       run: |
-        pushd /tmp/IDE/com.ibm.wala.cast.lsp
+        pushd ./IDE/com.ibm.wala.cast.lsp
         mvn clean install -B -q -DskipTests
         popd
     - name: Check formatting with spotless.

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,15 +29,18 @@ jobs:
         path: ./jython3
     - name: Install Jython3.
       run: |
-        cd ./jython3
+        pushd ./jython3
         ant
-        cd dist
+        pushd dist
         mvn install:install-file -Dfile=./jython-dev.jar -DgroupId="org.python" -DartifactId="jython3" -Dversion="0.0.1-SNAPSHOT" -Dpackaging="jar" -DgeneratePom=true
+        popd
+        popd
       shell: bash
     - name: Install IDE.
       run: |
-        cd ./IDE/com.ibm.wala.cast.lsp
+        pushd ./IDE/com.ibm.wala.cast.lsp
         mvn clean install -B -q -DskipTests
+        popd
     - name: Check formatting with spotless.
       run: mvn spotless:check -B
     - name: Build with Maven

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,19 +17,12 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Checkout wala/IDE sources.
-      uses: actions/checkout@v3.5.2
-      with:
-        repository: wala/IDE
-        # fetch-depth: 50
-        path: ./IDE
+      run: git clone --depth=50 https://github.com/wala/IDE ${{ runner.temp }}/IDE
     - name: Checkout juliandolby/jython3 sources.
-      uses: actions/checkout@v3.5.2
-      with:
-        repository: juliandolby/jython3
-        path: ./jython3
+      run: git clone https://github.com/juliandolby/jython3.git ${{ runner.temp }}/jython3
     - name: Install Jython3.
       run: |
-        pushd ./jython3
+        pushd ${{ runner.temp }}/jython3
         ant
         pushd dist
         mvn install:install-file -Dfile=./jython-dev.jar -DgroupId="org.python" -DartifactId="jython3" -Dversion="0.0.1-SNAPSHOT" -Dpackaging="jar" -DgeneratePom=true
@@ -38,7 +31,7 @@ jobs:
       shell: bash
     - name: Install IDE.
       run: |
-        pushd ./IDE/com.ibm.wala.cast.lsp
+        pushd ${{ runner.temp }}/IDE/com.ibm.wala.cast.lsp
         mvn clean install -B -q -DskipTests
         popd
     - name: Check formatting with spotless.

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,15 +21,15 @@ jobs:
       with:
         repository: wala/IDE
         # fetch-depth: 50
-        path: ${{ runner.temp }}/IDE
+        path: /tmp/IDE
     - name: Checkout juliandolby/jython3 sources.
       uses: actions/checkout@v3.5.2
       with:
         repository: juliandolby/jython3
-        path: ${{ runner.temp }}/jython3
+        path: /tmp/jython3
     - name: Install Jython3.
       run: |
-        pushd ${{ runner.temp }}/jython3
+        pushd /tmp/jython3
         ant
         pushd dist
         mvn install:install-file -Dfile=./jython-dev.jar -DgroupId="org.python" -DartifactId="jython3" -Dversion="0.0.1-SNAPSHOT" -Dpackaging="jar" -DgeneratePom=true
@@ -38,7 +38,7 @@ jobs:
       shell: bash
     - name: Install IDE.
       run: |
-        pushd ${{ runner.temp }}/IDE/com.ibm.wala.cast.lsp
+        pushd /tmp/IDE/com.ibm.wala.cast.lsp
         mvn clean install -B -q -DskipTests
         popd
     - name: Check formatting with spotless.

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,9 +17,9 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Checkout wala/IDE sources.
-      run: git clone --depth=50 https://github.com/wala/IDE ${{ runner.temp }}/IDE
+      run: git clone --depth=1 https://github.com/wala/IDE ${{ runner.temp }}/IDE
     - name: Checkout juliandolby/jython3 sources.
-      run: git clone https://github.com/juliandolby/jython3.git ${{ runner.temp }}/jython3
+      run: git clone --depth=1 https://github.com/juliandolby/jython3.git ${{ runner.temp }}/jython3
     - name: Install Jython3.
       run: |
         pushd ${{ runner.temp }}/jython3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,15 +21,15 @@ jobs:
       with:
         repository: wala/IDE
         # fetch-depth: 50
-        path: ./IDE
+        path: /tmp/IDE
     - name: Checkout juliandolby/jython3 sources.
       uses: actions/checkout@v3.5.2
       with:
         repository: juliandolby/jython3
-        path: ./jython3
+        path: /tmp/jython3
     - name: Install Jython3.
       run: |
-        pushd ./jython3
+        pushd /tmp/jython3
         ant
         pushd dist
         mvn install:install-file -Dfile=./jython-dev.jar -DgroupId="org.python" -DartifactId="jython3" -Dversion="0.0.1-SNAPSHOT" -Dpackaging="jar" -DgeneratePom=true
@@ -38,7 +38,7 @@ jobs:
       shell: bash
     - name: Install IDE.
       run: |
-        pushd ./IDE/com.ibm.wala.cast.lsp
+        pushd /tmp/IDE/com.ibm.wala.cast.lsp
         mvn clean install -B -q -DskipTests
         popd
     - name: Check formatting with spotless.

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,15 +21,15 @@ jobs:
       with:
         repository: wala/IDE
         # fetch-depth: 50
-        path: /tmp/IDE
+        path: ${{ runner.temp }}/IDE
     - name: Checkout juliandolby/jython3 sources.
       uses: actions/checkout@v3.5.2
       with:
         repository: juliandolby/jython3
-        path: /tmp/jython3
+        path: ${{ runner.temp }}/jython3
     - name: Install Jython3.
       run: |
-        pushd /tmp/jython3
+        pushd ${{ runner.temp }}/jython3
         ant
         pushd dist
         mvn install:install-file -Dfile=./jython-dev.jar -DgroupId="org.python" -DartifactId="jython3" -Dversion="0.0.1-SNAPSHOT" -Dpackaging="jar" -DgeneratePom=true
@@ -38,7 +38,7 @@ jobs:
       shell: bash
     - name: Install IDE.
       run: |
-        pushd /tmp/IDE/com.ibm.wala.cast.lsp
+        pushd ${{ runner.temp }}/IDE/com.ibm.wala.cast.lsp
         mvn clean install -B -q -DskipTests
         popd
     - name: Check formatting with spotless.

--- a/com.ibm.wala.cast.python.jython/data/functools.xml
+++ b/com.ibm.wala.cast.python.jython/data/functools.xml
@@ -4,43 +4,29 @@
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="functools" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lfunctools;">
-        <new def="x" class="Lfunctools"/>
+      <method name="import" static="true" descriptor="()Lfunctools;">
+        <new def="x" class="Lfunctools" />
 
-	<new def="reduce" class="Lfunctools/functions/reduce"/>
-	<putfield class="LRoot"
-                  field="reduce"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="reduce"/>
+        <new def="reduce" class="Lfunctools/functions/reduce" />
+        <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="reduce" />
 
-	<return value="x"/>
+        <return value="x" />
       </method>
     </class>
 
     <package name="functools/functions">
 
       <class name="reduce" allocatable="true">
-	<method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self lambda data">
-	  <constant name="l" type="int" value="0"/>
-	  <aaload ref="data" def="v1" type="LRoot" index="l"/>
-	  <constant name="r" type="int" value="1"/>
-	  <aaload ref="data" def="v2" type="LRoot" index="r"/>
-	  <call class="LRoot"
-		name="do"
-		descriptor="()LRoot;"
-		type="virtual"
-		arg0="lambda"
-		arg1="v1"
-		arg2="v2"
-		numArgs="3"
-		def="v"/>
-	  <return value="v"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self lambda data">
+          <constant name="l" type="int" value="0" />
+          <aaload ref="data" def="v1" type="LRoot" index="l" />
+          <constant name="r" type="int" value="1" />
+          <aaload ref="data" def="v2" type="LRoot" index="r" />
+          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="lambda" arg1="v1" arg2="v2" numArgs="3" def="v" />
+          <return value="v" />
+        </method>
       </class>
-      
+
     </package>
   </classloader>
 </summary-spec>

--- a/com.ibm.wala.cast.python.jython/data/numpy_turtle.xml
+++ b/com.ibm.wala.cast.python.jython/data/numpy_turtle.xml
@@ -4,16 +4,10 @@
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lnumpy;">
-        <new def="x" class="Lturtle"/>
- 		<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Lnumpy;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python.jython/data/pandas.xml
+++ b/com.ibm.wala.cast.python.jython/data/pandas.xml
@@ -4,44 +4,33 @@
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="pandas" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lpandas;">
-        <new def="x" class="Lpandas"/>
+      <method name="import" static="true" descriptor="()Lpandas;">
+        <new def="x" class="Lpandas" />
 
-	<new def="read_excel" class="Lpandas/functions/read_excel"/>
-	<putfield class="LRoot"
-                  field="read_excel"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="read_excel"/>
+        <new def="read_excel" class="Lpandas/functions/read_excel" />
+        <putfield class="LRoot" field="read_excel" fieldType="LRoot" ref="x" value="read_excel" />
 
-	<new def="merge" class="Lpandas/functions/merge"/>
-	<putfield class="LRoot"
-                  field="merge"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="merge"/>
+        <new def="merge" class="Lpandas/functions/merge" />
+        <putfield class="LRoot" field="merge" fieldType="LRoot" ref="x" value="merge" />
 
-	<return value="x"/>
+        <return value="x" />
       </method>
     </class>
 
     <package name="pandas/functions">
 
       <class name="read_excel" allocatable="true">
-	<method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self file sheet">
-	  <new def="v" class="Lobject"/>
-	  <return value="v"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self file sheet">
+          <new def="v" class="Lobject" />
+          <return value="v" />
+        </method>
       </class>
 
       <class name="merge" allocatable="true">
-        <method name="do" descriptor="()LRoot;" numArgs="5"
-		paramNames="self left right on how">
-	  <return value="left"/>
-	  <return value="right"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self left right on how">
+          <return value="left" />
+          <return value="right" />
+        </method>
       </class>
     </package>
   </classloader>

--- a/com.ibm.wala.cast.python.jython/data/turtles.xml
+++ b/com.ibm.wala.cast.python.jython/data/turtles.xml
@@ -4,146 +4,80 @@
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lnumpy;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Lnumpy;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
     <class name="sklearn" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lsklearn;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Lsklearn;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
     <class name="pandas" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lpandas;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Lpandas;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
     <class name="patsy" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lpatsy;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Lpatsy;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
     <class name="seaborn" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lseaborn;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Lseaborn;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
-     <class name="statsmodels" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lstatsmodels;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+    <class name="statsmodels" allocatable="true">
+      <method name="import" static="true" descriptor="()Lstatsmodels;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
-        <class name="scipy" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lscipy;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+    <class name="scipy" allocatable="true">
+      <method name="import" static="true" descriptor="()Lscipy;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
-     <class name="matplotlib" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lmatplotlib;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+    <class name="matplotlib" allocatable="true">
+      <method name="import" static="true" descriptor="()Lmatplotlib;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
     <class name="IPython" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()LIPython;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()LIPython;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
-     <class name="mpl_toolkits" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lmpl_toolkits;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+    <class name="mpl_toolkits" allocatable="true">
+      <method name="import" static="true" descriptor="()Lmpl_toolkits;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
     <class name="tensorflow" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Ltensorflow;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Ltensorflow;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python.jython3/data/functools.xml
+++ b/com.ibm.wala.cast.python.jython3/data/functools.xml
@@ -4,43 +4,29 @@
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="functools" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lfunctools;">
-        <new def="x" class="Lfunctools"/>
+      <method name="import" static="true" descriptor="()Lfunctools;">
+        <new def="x" class="Lfunctools" />
 
-	<new def="reduce" class="Lfunctools/functions/reduce"/>
-	<putfield class="LRoot"
-                  field="reduce"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="reduce"/>
+        <new def="reduce" class="Lfunctools/functions/reduce" />
+        <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="reduce" />
 
-	<return value="x"/>
+        <return value="x" />
       </method>
     </class>
 
     <package name="functools/functions">
 
       <class name="reduce" allocatable="true">
-	<method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self lambda data">
-	  <constant name="l" type="int" value="0"/>
-	  <aaload ref="data" def="v1" type="LRoot" index="l"/>
-	  <constant name="r" type="int" value="1"/>
-	  <aaload ref="data" def="v2" type="LRoot" index="r"/>
-	  <call class="LRoot"
-		name="do"
-		descriptor="()LRoot;"
-		type="virtual"
-		arg0="lambda"
-		arg1="v1"
-		arg2="v2"
-		numArgs="3"
-		def="v"/>
-	  <return value="v"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self lambda data">
+          <constant name="l" type="int" value="0" />
+          <aaload ref="data" def="v1" type="LRoot" index="l" />
+          <constant name="r" type="int" value="1" />
+          <aaload ref="data" def="v2" type="LRoot" index="r" />
+          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="lambda" arg1="v1" arg2="v2" numArgs="3" def="v" />
+          <return value="v" />
+        </method>
       </class>
-      
+
     </package>
   </classloader>
 </summary-spec>

--- a/com.ibm.wala.cast.python.jython3/data/numpy_turtle.xml
+++ b/com.ibm.wala.cast.python.jython3/data/numpy_turtle.xml
@@ -4,16 +4,10 @@
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lnumpy;">
-        <new def="x" class="Lturtle"/>
- 		<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Lnumpy;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python.jython3/data/pandas.xml
+++ b/com.ibm.wala.cast.python.jython3/data/pandas.xml
@@ -4,44 +4,33 @@
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="pandas" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lpandas;">
-        <new def="x" class="Lpandas"/>
+      <method name="import" static="true" descriptor="()Lpandas;">
+        <new def="x" class="Lpandas" />
 
-	<new def="read_excel" class="Lpandas/functions/read_excel"/>
-	<putfield class="LRoot"
-                  field="read_excel"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="read_excel"/>
+        <new def="read_excel" class="Lpandas/functions/read_excel" />
+        <putfield class="LRoot" field="read_excel" fieldType="LRoot" ref="x" value="read_excel" />
 
-	<new def="merge" class="Lpandas/functions/merge"/>
-	<putfield class="LRoot"
-                  field="merge"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="merge"/>
+        <new def="merge" class="Lpandas/functions/merge" />
+        <putfield class="LRoot" field="merge" fieldType="LRoot" ref="x" value="merge" />
 
-	<return value="x"/>
+        <return value="x" />
       </method>
     </class>
 
     <package name="pandas/functions">
 
       <class name="read_excel" allocatable="true">
-	<method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self file sheet">
-	  <new def="v" class="Lobject"/>
-	  <return value="v"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self file sheet">
+          <new def="v" class="Lobject" />
+          <return value="v" />
+        </method>
       </class>
 
       <class name="merge" allocatable="true">
-        <method name="do" descriptor="()LRoot;" numArgs="5"
-		paramNames="self left right on how">
-	  <return value="left"/>
-	  <return value="right"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self left right on how">
+          <return value="left" />
+          <return value="right" />
+        </method>
       </class>
     </package>
   </classloader>

--- a/com.ibm.wala.cast.python.jython3/data/turtles.xml
+++ b/com.ibm.wala.cast.python.jython3/data/turtles.xml
@@ -4,146 +4,80 @@
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lnumpy;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Lnumpy;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
     <class name="sklearn" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lsklearn;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Lsklearn;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
     <class name="pandas" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lpandas;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Lpandas;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
     <class name="patsy" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lpatsy;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Lpatsy;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
     <class name="seaborn" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lseaborn;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Lseaborn;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
-     <class name="statsmodels" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lstatsmodels;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+    <class name="statsmodels" allocatable="true">
+      <method name="import" static="true" descriptor="()Lstatsmodels;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
-        <class name="scipy" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lscipy;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+    <class name="scipy" allocatable="true">
+      <method name="import" static="true" descriptor="()Lscipy;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
-     <class name="matplotlib" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lmatplotlib;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+    <class name="matplotlib" allocatable="true">
+      <method name="import" static="true" descriptor="()Lmatplotlib;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
     <class name="IPython" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()LIPython;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()LIPython;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
-     <class name="mpl_toolkits" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lmpl_toolkits;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+    <class name="mpl_toolkits" allocatable="true">
+      <method name="import" static="true" descriptor="()Lmpl_toolkits;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
     <class name="tensorflow" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Ltensorflow;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Ltensorflow;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python.ml.j2ee/.settings/org.eclipse.wst.common.project.facet.core.xml
+++ b/com.ibm.wala.cast.python.ml.j2ee/.settings/org.eclipse.wst.common.project.facet.core.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <faceted-project>
-  <runtime name="Apache Tomcat v9.0"/>
-  <fixed facet="jst.web"/>
-  <fixed facet="java"/>
-  <fixed facet="wst.jsdt.web"/>
-  <installed facet="java" version="1.8"/>
-  <installed facet="jst.web" version="3.1"/>
-  <installed facet="wst.jsdt.web" version="1.0"/>
+  <runtime name="Apache Tomcat v9.0" />
+  <fixed facet="jst.web" />
+  <fixed facet="java" />
+  <fixed facet="wst.jsdt.web" />
+  <installed facet="java" version="1.8" />
+  <installed facet="jst.web" version="3.1" />
+  <installed facet="wst.jsdt.web" version="1.0" />
 </faceted-project>

--- a/com.ibm.wala.cast.python.ml.j2ee/pom.xml
+++ b/com.ibm.wala.cast.python.ml.j2ee/pom.xml
@@ -1,50 +1,51 @@
-    <project>
-      <modelVersion>4.0.0</modelVersion>
-      <groupId>com.ibm.wala</groupId>
-      <artifactId>com.ibm.wala.cast.python.ml.j2ee</artifactId>
-      <version>0.0.1-SNAPSHOT</version>
-      <build>
-	<sourceDirectory>source</sourceDirectory>
-        <plugins>
-	  <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.7.0</version>
-            <configuration>
-              <source>1.8</source>
-              <target>1.8</target>
-            </configuration>
-	  </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-war-plugin</artifactId>
-            <version>3.2.2</version>
-            <configuration>
-	      <warSourceDirectory>WebContent</warSourceDirectory>
-              <archive>
-                <manifest>
-                  <addClasspath>true</addClasspath>
-                </manifest>
-              </archive>
-            </configuration>
-	    <executions>
-	      <execution>
-		<id>build-war</id>
-		<phase>install</phase>
-		<goals>
-		  <goal>war</goal>
-		</goals>
-	      </execution>
-	    </executions>
-          </plugin>
-        </plugins>
-      </build>
-      <dependencies>
- <dependency>
-    <groupId>javax.websocket</groupId>
-    <artifactId>javax.websocket-api</artifactId>
-    <version>1.1</version>
-    <scope>provided</scope>
-</dependency>
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.ibm.wala</groupId>
+  <artifactId>com.ibm.wala.cast.python.ml.j2ee</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <build>
+    <sourceDirectory>source</sourceDirectory>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.7.0</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.2.2</version>
+        <configuration>
+          <warSourceDirectory>WebContent</warSourceDirectory>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+        <executions>
+          <execution>
+            <id>build-war</id>
+            <phase>install</phase>
+            <goals>
+              <goal>war</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>javax.websocket</groupId>
+      <artifactId>javax.websocket-api</artifactId>
+      <version>1.1</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
@@ -97,4 +98,4 @@
     </dependency>
   </dependencies>
 
-    </project>
+</project>

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -4,472 +4,255 @@
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="tensorflow" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Ltensorflow;">
-        <new def="x" class="Ltensorflow"/>
+      <method name="import" static="true" descriptor="()Ltensorflow;">
+        <new def="x" class="Ltensorflow" />
 
-	<new def="train" class="Lobject"/>
-	<putfield class="LRoot"
-                  field="train"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="train"/>
+        <new def="train" class="Lobject" />
+        <putfield class="LRoot" field="train" fieldType="LRoot" ref="x" value="train" />
 
-	<new def="AdamOptimizer"
-	     class="Ltensorflow/functions/AdamOptimizer"/>
-	<putfield class="LRoot"
-                  field="AdamOptimizer"
-                  fieldType="LRoot"
-                  ref="train"
-                  value="AdamOptimizer"/>
-	
-	<new def="shuffle_batch"
-	     class="Ltensorflow/functions/shuffle_batch"/>
-	<putfield class="LRoot"
-                  field="shuffle_batch"
-                  fieldType="LRoot"
-                  ref="train"
-                  value="shuffle_batch"/>
+        <new def="AdamOptimizer" class="Ltensorflow/functions/AdamOptimizer" />
+        <putfield class="LRoot" field="AdamOptimizer" fieldType="LRoot" ref="train" value="AdamOptimizer" />
 
-	<new def="InteractiveSession" class="Ltensorflow/functions/InteractiveSession"/>
-	<putfield class="LRoot"
-                  field="InteractiveSession"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="InteractiveSession"/>
-	<putfield class="LRoot"
-                  field="Session"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="InteractiveSession"/>
-	
-	<new def="parse_single_example"
-	     class="Ltensorflow/functions/parse_single_example"/>
-	<putfield class="LRoot"
-                  field="parse_single_example"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="parse_single_example"/>
-	
-	<new def="FixedLenFeature"
-	     class="Ltensorflow/functions/FixedLenFeature"/>
-	<putfield class="LRoot"
-                  field="FixedLenFeature"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="FixedLenFeature"/>
-	
-	<new def="pass_through"
-	     class="Ltensorflow/functions/pass_through"/>
-	<putfield class="LRoot"
-                  field="cast"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="pass_through"/>
-	<putfield class="LRoot"
-                  field="decode_raw"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="pass_through"/>
-	
-        <new def="estimator" class="Lobject"/>
-	<putfield class="LRoot"
-                  field="estimator"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="estimator"/>
+        <new def="shuffle_batch" class="Ltensorflow/functions/shuffle_batch" />
+        <putfield class="LRoot" field="shuffle_batch" fieldType="LRoot" ref="train" value="shuffle_batch" />
 
-        <new def="nn" class="Lobject"/>
-	<putfield class="LRoot"
-                  field="nn"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="nn"/>
-        <new def="layers" class="Lobject"/>
-	<putfield class="LRoot"
-                  field="layers"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="layers"/>
+        <new def="InteractiveSession" class="Ltensorflow/functions/InteractiveSession" />
+        <putfield class="LRoot" field="InteractiveSession" fieldType="LRoot" ref="x" value="InteractiveSession" />
+        <putfield class="LRoot" field="Session" fieldType="LRoot" ref="x" value="InteractiveSession" />
 
-	<new def="app" class="Lobject"/>
-	<putfield class="LRoot"
-                  field="app"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="app"/>
-	<new def="run" class="Ltensorflow/app/run"/>
-	<putfield class="LRoot"
-                  field="run"
-                  fieldType="LRoot"
-                  ref="app"
-                  value="run"/>
+        <new def="parse_single_example" class="Ltensorflow/functions/parse_single_example" />
+        <putfield class="LRoot" field="parse_single_example" fieldType="LRoot" ref="x" value="parse_single_example" />
 
-	<new def="Estimator" class="Ltensorflow/estimator/Estimator"/>
-	<putfield class="LRoot"
-                  field="Estimator"
-                  fieldType="LRoot"
-                  ref="estimator"
-                  value="Estimator"/>
+        <new def="FixedLenFeature" class="Ltensorflow/functions/FixedLenFeature" />
+        <putfield class="LRoot" field="FixedLenFeature" fieldType="LRoot" ref="x" value="FixedLenFeature" />
 
-	<new def="inputs" class="Lobject"/>
-	<putfield class="LRoot"
-                  field="inputs"
-                  fieldType="LRoot"
-                  ref="estimator"
-                  value="inputs"/>
+        <new def="pass_through" class="Ltensorflow/functions/pass_through" />
+        <putfield class="LRoot" field="cast" fieldType="LRoot" ref="x" value="pass_through" />
+        <putfield class="LRoot" field="decode_raw" fieldType="LRoot" ref="x" value="pass_through" />
 
-	<new def="numpy_input_fn" class="Ltensorflow/estimator/numpy_input_fn"/>
-	<putfield class="LRoot"
-                  field="numpy_input_fn"
-                  fieldType="LRoot"
-                  ref="inputs"
-                  value="numpy_input_fn"/>
+        <new def="estimator" class="Lobject" />
+        <putfield class="LRoot" field="estimator" fieldType="LRoot" ref="x" value="estimator" />
 
-	<new def="reshape" class="Ltensorflow/functions/reshape"/>
-	<putfield class="LRoot"
-                  field="reshape"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="reshape"/>
+        <new def="nn" class="Lobject" />
+        <putfield class="LRoot" field="nn" fieldType="LRoot" ref="x" value="nn" />
+        <new def="layers" class="Lobject" />
+        <putfield class="LRoot" field="layers" fieldType="LRoot" ref="x" value="layers" />
 
-	<new def="conv2d" class="Ltensorflow/functions/conv2d"/>
-	<putfield class="LRoot"
-                  field="conv2d"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="conv2d"/>
-	<putfield class="LRoot"
-                  field="conv2d"
-                  fieldType="LRoot"
-                  ref="nn"
-                  value="conv2d"/>
-	<putfield class="LRoot"
-                  field="conv2d"
-                  fieldType="LRoot"
-                  ref="layers"
-                  value="conv2d"/>
+        <new def="app" class="Lobject" />
+        <putfield class="LRoot" field="app" fieldType="LRoot" ref="x" value="app" />
+        <new def="run" class="Ltensorflow/app/run" />
+        <putfield class="LRoot" field="run" fieldType="LRoot" ref="app" value="run" />
 
-	<new def="conv3d" class="Ltensorflow/functions/conv3d"/>
-	<putfield class="LRoot"
-                  field="conv3d"
-                  fieldType="LRoot"
-                  ref="nn"
-                  value="conv3d"/>
+        <new def="Estimator" class="Ltensorflow/estimator/Estimator" />
+        <putfield class="LRoot" field="Estimator" fieldType="LRoot" ref="estimator" value="Estimator" />
 
-	<new def="placeholder"
-	     class="Ltensorflow/functions/placeholder"/>
-	<putfield class="LRoot"
-                  field="placeholder"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="placeholder"/>
+        <new def="inputs" class="Lobject" />
+        <putfield class="LRoot" field="inputs" fieldType="LRoot" ref="estimator" value="inputs" />
 
-	<new def="examples"  class="Lobject"/>
-	<putfield class="LRoot"
-                  field="examples"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="examples"/>
-	<new def="tutorials"  class="Lobject"/>
-	<putfield class="LRoot"
-                  field="tutorials"
-                  fieldType="LRoot"
-                  ref="examples"
-                  value="tutorials"/>
-	<new def="mnist"  class="Lobject"/>
-	<putfield class="LRoot"
-                  field="mnist"
-                  fieldType="LRoot"
-                  ref="tutorials"
-                  value="mnist"/>
-          <new def="id" class="Ltensorflow/examples/tutorials/mnist/input_data"/>
-          <putfield class="LRoot"
-                    field="input_data"
-                    fieldType="LRoot"
-                    ref="mnist"
-                    value="id"/>
-          <new def="rds" class="Ltensorflow/examples/tutorials/mnist/read_data_sets"/>
-          <putfield class="LRoot"
-                    field="read_data_sets"
-                    fieldType="LRoot"
-                    ref="id"
-                    value="rds"/>
-	
-	<return value="x"/>
+        <new def="numpy_input_fn" class="Ltensorflow/estimator/numpy_input_fn" />
+        <putfield class="LRoot" field="numpy_input_fn" fieldType="LRoot" ref="inputs" value="numpy_input_fn" />
+
+        <new def="reshape" class="Ltensorflow/functions/reshape" />
+        <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="x" value="reshape" />
+
+        <new def="conv2d" class="Ltensorflow/functions/conv2d" />
+        <putfield class="LRoot" field="conv2d" fieldType="LRoot" ref="x" value="conv2d" />
+        <putfield class="LRoot" field="conv2d" fieldType="LRoot" ref="nn" value="conv2d" />
+        <putfield class="LRoot" field="conv2d" fieldType="LRoot" ref="layers" value="conv2d" />
+
+        <new def="conv3d" class="Ltensorflow/functions/conv3d" />
+        <putfield class="LRoot" field="conv3d" fieldType="LRoot" ref="nn" value="conv3d" />
+
+        <new def="placeholder" class="Ltensorflow/functions/placeholder" />
+        <putfield class="LRoot" field="placeholder" fieldType="LRoot" ref="x" value="placeholder" />
+
+        <new def="examples" class="Lobject" />
+        <putfield class="LRoot" field="examples" fieldType="LRoot" ref="x" value="examples" />
+        <new def="tutorials" class="Lobject" />
+        <putfield class="LRoot" field="tutorials" fieldType="LRoot" ref="examples" value="tutorials" />
+        <new def="mnist" class="Lobject" />
+        <putfield class="LRoot" field="mnist" fieldType="LRoot" ref="tutorials" value="mnist" />
+        <new def="id" class="Ltensorflow/examples/tutorials/mnist/input_data" />
+        <putfield class="LRoot" field="input_data" fieldType="LRoot" ref="mnist" value="id" />
+        <new def="rds" class="Ltensorflow/examples/tutorials/mnist/read_data_sets" />
+        <putfield class="LRoot" field="read_data_sets" fieldType="LRoot" ref="id" value="rds" />
+
+        <return value="x" />
       </method>
     </class>
-	
+
     <package name="tensorflow/objects">
-      <class name="feature" allocatable="true"/>
+      <class name="feature" allocatable="true" />
     </package>
-    
+
     <package name="tensorflow/functions">
 
       <class name="AdamOptimizer" allocatable="true">
-	<method name="do" descriptor="()LRoot;">
-	  <new def="opt" class="Lobject"/>
+        <method name="do" descriptor="()LRoot;">
+          <new def="opt" class="Lobject" />
 
-	  <new def="minimize" class="Ltensorflow/functions/minimize"/>
-	  <putfield class="LRoot"
-                    field="minimize"
-                    fieldType="LRoot"
-                    ref="opt"
-                    value="minimize"/>
+          <new def="minimize" class="Ltensorflow/functions/minimize" />
+          <putfield class="LRoot" field="minimize" fieldType="LRoot" ref="opt" value="minimize" />
 
-	  <return value="opt"/>
-	</method>
+          <return value="opt" />
+        </method>
       </class>
 
       <class name="minimize" allocatable="true">
-	<method name="do" descriptor="()LRoot;">
-	  <new def="v" class="Lobject"/>
-	  <new def="f" class="Ltensorflow/functions/Runner"/>
-	  <putfield class="LRoot"
-                    field="run"
-                    fieldType="LRoot"
-                    ref="v"
-                    value="f"/>
-	  <return value="v"/>
-	</method>
+        <method name="do" descriptor="()LRoot;">
+          <new def="v" class="Lobject" />
+          <new def="f" class="Ltensorflow/functions/Runner" />
+          <putfield class="LRoot" field="run" fieldType="LRoot" ref="v" value="f" />
+          <return value="v" />
+        </method>
       </class>
-      
+
       <class name="shuffle_batch" allocatable="true">
-	<method name="do" descriptor="()LRoot;" numArgs="3"
-		paramNames="self data">
-	  <return value="data"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self data">
+          <return value="data" />
+        </method>
       </class>
-      
+
       <class name="InteractiveSession" allocatable="true">
-	<method name="do" descriptor="()LRoot;">
-	  <new def="v" class="Lobject"/>
-	  <new def="f" class="Ltensorflow/functions/Runner"/>
-	  <putfield class="LRoot"
-                    field="run"
-                    fieldType="LRoot"
-                    ref="v"
-                    value="f"/>
-	  <return value="v"/>
-	</method>
+        <method name="do" descriptor="()LRoot;">
+          <new def="v" class="Lobject" />
+          <new def="f" class="Ltensorflow/functions/Runner" />
+          <putfield class="LRoot" field="run" fieldType="LRoot" ref="v" value="f" />
+          <return value="v" />
+        </method>
       </class>
-      
+
       <class name="Runner" allocatable="true">
-	<method name="do" descriptor="()LRoot;" numArgs="3"
-		paramNames="self graph feed_dict">
-	  <return value="self"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self graph feed_dict">
+          <return value="self" />
+        </method>
       </class>
 
       <class name="set_shape" allocatable="true">
-	<method name="do" descriptor="()LRoot;" numArgs="2"
-		paramNames="self shape">
-	  <return value="self"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self shape">
+          <return value="self" />
+        </method>
       </class>
 
       <class name="reshape" allocatable="true">
-	<method name="copy_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/examples/tutorials/mnist/dataset"/>
-	  <return value="x"/>
-	</method>
+        <method name="copy_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/examples/tutorials/mnist/dataset" />
+          <return value="x" />
+        </method>
 
         <method name="do" descriptor="()LRoot;" numArgs="3">
-	  <call class="LRoot"
-		name="copy_data"
-		descriptor="()LRoot;"
-		type="virtual"
-		arg0="arg0"
-		def="x"/>
-	  <return value="x"/>
-	</method>
+          <call class="LRoot" name="copy_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
       </class>
 
       <class name="placeholder" allocatable="true">
-	<method name="do" descriptor="()LRoot;" numArgs="3"
-		paramNames="dtype shape name">
-	  <new def="x" class="Lobject"/>
-	  <return value="x"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="dtype shape name">
+          <new def="x" class="Lobject" />
+          <return value="x" />
+        </method>
       </class>
-      
+
       <class name="pass_through" allocatable="true">
-	<method name="do" descriptor="()LRoot;" numArgs="3"
-		paramNames="self data features">
-	  <return value="data"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self data features">
+          <return value="data" />
+        </method>
       </class>
-      
+
       <class name="parse_single_example" allocatable="true">
-	<method name="do" descriptor="()LRoot;" numArgs="3"
-		paramNames="self data features">
-	  <return value="features"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self data features">
+          <return value="features" />
+        </method>
       </class>
-      
-     <class name="FixedLenFeature" allocatable="true">
-	<method name="do" descriptor="()LRoot;" numArgs="3"
-		paramNames="self dims type">
-	  <new def="x" class="Ltensorflow/objects/feature"/>
 
-	  <new def="y" class="Ltensorflow/functions/set_shape"/>
-	  <putfield class="LRoot"
-                    field="set_shape"
-                    fieldType="LRoot"
-                    ref="x"
-                    value="y"/>
+      <class name="FixedLenFeature" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self dims type">
+          <new def="x" class="Ltensorflow/objects/feature" />
 
-	  <return value="x"/>
-	</method>
+          <new def="y" class="Ltensorflow/functions/set_shape" />
+          <putfield class="LRoot" field="set_shape" fieldType="LRoot" ref="x" value="y" />
+
+          <return value="x" />
+        </method>
       </class>
-      
+
       <class name="conv2d" allocatable="true">
-        <method name="do" descriptor="()LRoot;" numArgs="3"
-		paramNames="self x y">
-	  <return value="x"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x y">
+          <return value="x" />
+        </method>
       </class>
 
       <class name="conv3d" allocatable="true">
-        <method name="do" descriptor="()LRoot;" numArgs="3"
-		paramNames="self x y">
-	  <return value="x"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x y">
+          <return value="x" />
+        </method>
       </class>
     </package>
-    
-   <package name="tensorflow/estimator">
+
+    <package name="tensorflow/estimator">
       <class name="Estimator" allocatable="true">
-        <method name="do" descriptor="()LRoot;" numArgs="2"
-		paramNames="self model">
-          <new def="x" class="Ltensorflow/estimator/train/train"/>
-	  <putfield class="LRoot"
-                    field="train"
-                    fieldType="LRoot"
-                    ref="self"
-                    value="x"/>
-	  <putfield class="LRoot"
-                    field="$callback"
-                    fieldType="LRoot"
-                    ref="x"
-                    value="model"/>
-	  <return value="arg0"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self model">
+          <new def="x" class="Ltensorflow/estimator/train/train" />
+          <putfield class="LRoot" field="train" fieldType="LRoot" ref="self" value="x" />
+          <putfield class="LRoot" field="$callback" fieldType="LRoot" ref="x" value="model" />
+          <return value="arg0" />
+        </method>
       </class>
 
       <class name="numpy_input_fn" allocatable="true">
-        <method name="do" descriptor="()LRoot;" numArgs="5"
-        paramNames="self x y batch_size shuffle">
-          <new def="xx" class="Lobject"/>
-	  <putfield class="LRoot"
-                    field="data"
-                    fieldType="LRoot"
-                    ref="xx"
-                    value="2"/>
-	  <putfield class="LRoot"
-                    field="labels"
-                    fieldType="LRoot"
-                    ref="xx"
-                    value="3"/>
-	  <return value="xx"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self x y batch_size shuffle">
+          <new def="xx" class="Lobject" />
+          <putfield class="LRoot" field="data" fieldType="LRoot" ref="xx" value="2" />
+          <putfield class="LRoot" field="labels" fieldType="LRoot" ref="xx" value="3" />
+          <return value="xx" />
+        </method>
       </class>
-   </package>
-   
-   <package name="tensorflow/estimator/train">
+    </package>
+
+    <package name="tensorflow/estimator/train">
       <class name="train" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3">
-	  <getfield class="LRoot"
-                    field="$callback"
-                    fieldType="LRoot"
-                    ref="arg0"
-                    def="xx"/>
-	  <getfield class="LRoot"
-                    field="data"
-                    fieldType="LRoot"
-                    ref="arg1"
-                    def="data"/>
-	  <call class="LRoot"
-		name="do"
-		descriptor="()LRoot;"
-		type="virtual"
-		arg0="xx"
-		arg1="data"
-		arg2="3"
-		numArgs="3"
-		def="v"/>
-	  <return value="v"/>
-	</method>
+          <getfield class="LRoot" field="$callback" fieldType="LRoot" ref="arg0" def="xx" />
+          <getfield class="LRoot" field="data" fieldType="LRoot" ref="arg1" def="data" />
+          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="xx" arg1="data" arg2="3" numArgs="3" def="v" />
+          <return value="v" />
+        </method>
       </class>
     </package>
 
     <package name="tensorflow/app">
       <class name="run" allocatable="true">
-	<method name="do" descriptor="()LRoot;" numArgs="3"
-        paramNames="self main argv">
-	  <call class="LRoot"
-		name="do"
-		descriptor="()LRoot;"
-		type="virtual"
-		arg0="arg1"
-		arg1=""
-		def="v"/>
-	  <return value="v"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self main argv">
+          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="arg1" arg1="" def="v" />
+          <return value="v" />
+        </method>
       </class>
     </package>
-    
+
     <package name="tensorflow/examples/tutorials/mnist">
       <class name="read_data_sets" allocatable="true">
-	<method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/examples/tutorials/mnist/dataset"/>
-	  <return value="x"/>
-	</method>
-	
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/examples/tutorials/mnist/dataset" />
+          <return value="x" />
+        </method>
+
         <method name="do" descriptor="()LRoot;">
-          <new def="test" class="Lobject"/>
+          <new def="test" class="Lobject" />
 
-	  <call class="LRoot"
-		name="read_data"
-		descriptor="()LRoot;"
-		type="virtual"
-		arg0="arg0"
-		def="x"/>
-	  
-	  <putfield class="LRoot"
-                    field="images"
-                    fieldType="LRoot"
-                    ref="test"
-                    value="x"/>
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
 
-	  <call class="LRoot"
-		name="read_data"
-		descriptor="()LRoot;"
-		type="virtual"
-		arg0="arg0"
-		def="y"/>
+          <putfield class="LRoot" field="images" fieldType="LRoot" ref="test" value="x" />
 
-          <new def="training" class="Lobject"/>
-	  <putfield class="LRoot"
-                    field="images"
-                    fieldType="LRoot"
-                    ref="training"
-                    value="y"/>
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="y" />
 
-          <new def="data" class="Lobject"/>
-	  <putfield class="LRoot"
-                    field="test"
-                    fieldType="LRoot"
-                    ref="data"
-                    value="test"/>
-	  <putfield class="LRoot"
-                    field="train"
-                    fieldType="LRoot"
-                    ref="data"
-                    value="training"/>
+          <new def="training" class="Lobject" />
+          <putfield class="LRoot" field="images" fieldType="LRoot" ref="training" value="y" />
 
-          <return value="data"/>
+          <new def="data" class="Lobject" />
+          <putfield class="LRoot" field="test" fieldType="LRoot" ref="data" value="test" />
+          <putfield class="LRoot" field="train" fieldType="LRoot" ref="data" value="training" />
+
+          <return value="data" />
         </method>
       </class>
       <class name="input_data" allocatable="true">
@@ -480,30 +263,16 @@
 
     <package name="tensorflow/examples/tutorials">
       <class name="mnist" allocatable="true">
-        <method name="import"
-		static="true"
-		descriptor="()Ltensorflow/examples/tutorials/mnist;">
-          <new def="x" class="Ltensorflow/examples/tutorials/mnist"/>
-	  <call name="__init__"
-		class="Ltensorflow/examples/tutorials/mnist"
-		descriptor="()V"
-		type="virtual"
-		arg0="x" />
-	  <return value="x"/>
-	</method>
+        <method name="import" static="true" descriptor="()Ltensorflow/examples/tutorials/mnist;">
+          <new def="x" class="Ltensorflow/examples/tutorials/mnist" />
+          <call name="__init__" class="Ltensorflow/examples/tutorials/mnist" descriptor="()V" type="virtual" arg0="x" />
+          <return value="x" />
+        </method>
         <method name="__init__" descriptor="()V">
-          <new def="x" class="Ltensorflow/examples/tutorials/mnist/input_data"/>
-          <new def="y" class="Ltensorflow/examples/tutorials/mnist/read_data_sets"/>
-          <putfield class="Ltensorflow/examples/tutorials/mnist"
-                    field="input_data"
-                    fieldType="LRoot"
-                    ref="arg0"
-                    value="x"/>
-          <putfield class="Ltensorflow/examples/tutorials/mnist/input_data"
-                    field="read_data_sets"
-                    fieldType="LRoot"
-                    ref="x"
-                    value="y"/>
+          <new def="x" class="Ltensorflow/examples/tutorials/mnist/input_data" />
+          <new def="y" class="Ltensorflow/examples/tutorials/mnist/read_data_sets" />
+          <putfield class="Ltensorflow/examples/tutorials/mnist" field="input_data" fieldType="LRoot" ref="arg0" value="x" />
+          <putfield class="Ltensorflow/examples/tutorials/mnist/input_data" field="read_data_sets" fieldType="LRoot" ref="x" value="y" />
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python/data/flask.xml
+++ b/com.ibm.wala.cast.python/data/flask.xml
@@ -4,98 +4,69 @@
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="flask" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lflask;">
-        <new def="x" class="Lflask"/>
+      <method name="import" static="true" descriptor="()Lflask;">
+        <new def="x" class="Lflask" />
 
-		<new def="flask" class="Lflask/class/Flask"/>
-		<putfield class="LRoot"
-                  field="Flask"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="flask"/>
+        <new def="flask" class="Lflask/class/Flask" />
+        <putfield class="LRoot" field="Flask" fieldType="LRoot" ref="x" value="flask" />
 
-		<new def="request" class="Lobject"/>
-		<putfield class="LRoot"
-                  field="request"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="request"/>
+        <new def="request" class="Lobject" />
+        <putfield class="LRoot" field="request" fieldType="LRoot" ref="x" value="request" />
 
-		<new def="form" class="Lobject"/>
-		<putfield class="LRoot"
-                  field="form"
-                  fieldType="LRoot"
-                  ref="request"
-                  value="form"/>
+        <new def="form" class="Lobject" />
+        <putfield class="LRoot" field="form" fieldType="LRoot" ref="request" value="form" />
 
 
-		<return value="x"/>
+        <return value="x" />
       </method>
     </class>
-    
-   	<class name="subprocess" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lsubprocess;">
-        <new def="x" class="Lsubprocess"/>
-        
-        <new def="call" class="Lsubprocess/function/call"/>
-		<putfield class="LRoot"
-                  field="call"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="call"/>
 
-		<return value="x"/>
-	  </method>
+    <class name="subprocess" allocatable="true">
+      <method name="import" static="true" descriptor="()Lsubprocess;">
+        <new def="x" class="Lsubprocess" />
+
+        <new def="call" class="Lsubprocess/function/call" />
+        <putfield class="LRoot" field="call" fieldType="LRoot" ref="x" value="call" />
+
+        <return value="x" />
+      </method>
     </class>
-	
+
     <package name="flask/class">
-	    <class name="Flask" allocatable="true">
-			<method name="do" descriptor="()LRoot;">
-	  			<new def="v" class="Lobject"/>
+      <class name="Flask" allocatable="true">
+        <method name="do" descriptor="()LRoot;">
+          <new def="v" class="Lobject" />
 
-				<new def="route" class="Lflask/function/route"/>
-				<putfield class="LRoot"
-                  field="route"
-                  fieldType="LRoot"
-                  ref="v"
-                  value="route"/>
+          <new def="route" class="Lflask/function/route" />
+          <putfield class="LRoot" field="route" fieldType="LRoot" ref="v" value="route" />
 
-	  			<return value="v"/>
-			</method>
-		</class>
-	</package>
+          <return value="v" />
+        </method>
+      </class>
+    </package>
 
-   	<package name="flask/function">
-   		<class name="route" allocatable="true">
- 			<method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self entry">
-				<new def="v" class="Lflask/function/callback"/>
-				<return value="v"/>
-			</method>
-   		</class>
-   		<class name="callback" allocatable="true">
-   			<method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self entry">
-	 			<call class="LRoot"
-				name="do"
-				descriptor="()LRoot;"
-				type="virtual"
-				arg0="entry"
-				def="v"/>
-	  			<return value="v"/>
-			</method>
-		</class>
-	</package>	
-	
-	<package name="subprocess/function">
-   		<class name="call" allocatable="true">
- 			<method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self value shell">
-				<return value="self"/>
-			</method>
-   		</class>
-	</package>
-	
+    <package name="flask/function">
+      <class name="route" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self entry">
+          <new def="v" class="Lflask/function/callback" />
+          <return value="v" />
+        </method>
+      </class>
+      <class name="callback" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self entry">
+          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="entry" def="v" />
+          <return value="v" />
+        </method>
+      </class>
+    </package>
+
+    <package name="subprocess/function">
+      <class name="call" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self value shell">
+          <return value="self" />
+        </method>
+      </class>
+    </package>
+
   </classloader>
 </summary-spec>

--- a/com.ibm.wala.cast.python/data/functools.xml
+++ b/com.ibm.wala.cast.python/data/functools.xml
@@ -4,43 +4,29 @@
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="functools" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lfunctools;">
-        <new def="x" class="Lfunctools"/>
+      <method name="import" static="true" descriptor="()Lfunctools;">
+        <new def="x" class="Lfunctools" />
 
-	<new def="reduce" class="Lfunctools/functions/reduce"/>
-	<putfield class="LRoot"
-                  field="reduce"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="reduce"/>
+        <new def="reduce" class="Lfunctools/functions/reduce" />
+        <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="reduce" />
 
-	<return value="x"/>
+        <return value="x" />
       </method>
     </class>
 
     <package name="functools/functions">
 
       <class name="reduce" allocatable="true">
-	<method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self lambda data">
-	  <constant name="l" type="int" value="0"/>
-	  <aaload ref="data" def="v1" type="LRoot" index="l"/>
-	  <constant name="r" type="int" value="1"/>
-	  <aaload ref="data" def="v2" type="LRoot" index="r"/>
-	  <call class="LRoot"
-		name="do"
-		descriptor="()LRoot;"
-		type="virtual"
-		arg0="lambda"
-		arg1="v1"
-		arg2="v2"
-		numArgs="3"
-		def="v"/>
-	  <return value="v"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self lambda data">
+          <constant name="l" type="int" value="0" />
+          <aaload ref="data" def="v1" type="LRoot" index="l" />
+          <constant name="r" type="int" value="1" />
+          <aaload ref="data" def="v2" type="LRoot" index="r" />
+          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="lambda" arg1="v1" arg2="v2" numArgs="3" def="v" />
+          <return value="v" />
+        </method>
       </class>
-      
+
     </package>
   </classloader>
 </summary-spec>

--- a/com.ibm.wala.cast.python/data/numpy_turtle.xml
+++ b/com.ibm.wala.cast.python/data/numpy_turtle.xml
@@ -4,16 +4,10 @@
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lnumpy;">
-        <new def="x" class="Lturtle"/>
- 		<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Lnumpy;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python/data/pandas.xml
+++ b/com.ibm.wala.cast.python/data/pandas.xml
@@ -4,44 +4,33 @@
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="pandas" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lpandas;">
-        <new def="x" class="Lpandas"/>
+      <method name="import" static="true" descriptor="()Lpandas;">
+        <new def="x" class="Lpandas" />
 
-	<new def="read_excel" class="Lpandas/functions/read_excel"/>
-	<putfield class="LRoot"
-                  field="read_excel"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="read_excel"/>
+        <new def="read_excel" class="Lpandas/functions/read_excel" />
+        <putfield class="LRoot" field="read_excel" fieldType="LRoot" ref="x" value="read_excel" />
 
-	<new def="merge" class="Lpandas/functions/merge"/>
-	<putfield class="LRoot"
-                  field="merge"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="merge"/>
+        <new def="merge" class="Lpandas/functions/merge" />
+        <putfield class="LRoot" field="merge" fieldType="LRoot" ref="x" value="merge" />
 
-	<return value="x"/>
+        <return value="x" />
       </method>
     </class>
 
     <package name="pandas/functions">
 
       <class name="read_excel" allocatable="true">
-	<method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self file sheet">
-	  <new def="v" class="Lobject"/>
-	  <return value="v"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self file sheet">
+          <new def="v" class="Lobject" />
+          <return value="v" />
+        </method>
       </class>
 
       <class name="merge" allocatable="true">
-        <method name="do" descriptor="()LRoot;" numArgs="5"
-		paramNames="self left right on how">
-	  <return value="left"/>
-	  <return value="right"/>
-	</method>
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self left right on how">
+          <return value="left" />
+          <return value="right" />
+        </method>
       </class>
     </package>
   </classloader>

--- a/com.ibm.wala.cast.python/data/pytest.xml
+++ b/com.ibm.wala.cast.python/data/pytest.xml
@@ -4,69 +4,42 @@
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="pytest" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lpytest;">
-        <new def="x" class="Lpytest"/>
+      <method name="import" static="true" descriptor="()Lpytest;">
+        <new def="x" class="Lpytest" />
 
-	<new def="mark" class="Lobject"/>
-	<putfield class="LRoot"
-                  field="mark"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="mark"/>
-	
-	<new def="parametrize" class="Lpytest/class/parametrize"/>
-	<putfield class="LRoot"
-                  field="parametrize"
-                  fieldType="LRoot"
-                  ref="mark"
-                  value="parametrize"/>
+        <new def="mark" class="Lobject" />
+        <putfield class="LRoot" field="mark" fieldType="LRoot" ref="x" value="mark" />
 
-	<return value="x"/>
+        <new def="parametrize" class="Lpytest/class/parametrize" />
+        <putfield class="LRoot" field="parametrize" fieldType="LRoot" ref="mark" value="parametrize" />
+
+        <return value="x" />
       </method>
     </class>
-le     
+    le
     <package name="pytest/class">
 
       <class name="Parametrize" allocatable="true">
-	<method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self test">
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self test">
 
-	  <putfield class="LRoot"
-                    field="params"
-                    fieldType="LRoot"
-                    ref="test"
-                    value="self"/>
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self" />
 
-	  <return value="test"/>
-	</method>
+          <return value="test" />
+        </method>
       </class>
-      
+
       <class name="parametrize" allocatable="true">
-	<method name="do" descriptor="()LRoot;" numArgs="4"
-		paramNames="self params values extra">
-	  <new def="closure" class="Lpytest/class/Parametrize"/>
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self params values extra">
+          <new def="closure" class="Lpytest/class/Parametrize" />
 
-	  <putfield class="LRoot"
-                    field="test"
-                    fieldType="LRoot"
-                    ref="closure"
-                    value="self"/>
+          <putfield class="LRoot" field="test" fieldType="LRoot" ref="closure" value="self" />
 
-	  <putfield class="LRoot"
-                    field="params"
-                    fieldType="LRoot"
-                    ref="closure"
-                    value="params"/>
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="closure" value="params" />
 
-	  <putfield class="LRoot"
-                    field="values"
-                    fieldType="LRoot"
-                    ref="closure"
-                    value="values"/>
+          <putfield class="LRoot" field="values" fieldType="LRoot" ref="closure" value="values" />
 
-	  <return value="closure"/>
-	</method>
+          <return value="closure" />
+        </method>
       </class>
     </package>
 

--- a/com.ibm.wala.cast.python/data/turtles.xml
+++ b/com.ibm.wala.cast.python/data/turtles.xml
@@ -4,146 +4,80 @@
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lnumpy;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Lnumpy;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
     <class name="sklearn" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lsklearn;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Lsklearn;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
     <class name="pandas" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lpandas;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Lpandas;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
     <class name="patsy" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lpatsy;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Lpatsy;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
     <class name="seaborn" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lseaborn;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Lseaborn;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
-     <class name="statsmodels" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lstatsmodels;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+    <class name="statsmodels" allocatable="true">
+      <method name="import" static="true" descriptor="()Lstatsmodels;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
-        <class name="scipy" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lscipy;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+    <class name="scipy" allocatable="true">
+      <method name="import" static="true" descriptor="()Lscipy;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
-     <class name="matplotlib" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lmatplotlib;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+    <class name="matplotlib" allocatable="true">
+      <method name="import" static="true" descriptor="()Lmatplotlib;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
     <class name="IPython" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()LIPython;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()LIPython;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
-     <class name="mpl_toolkits" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Lmpl_toolkits;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+    <class name="mpl_toolkits" allocatable="true">
+      <method name="import" static="true" descriptor="()Lmpl_toolkits;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
     <class name="tensorflow" allocatable="true">
-      <method name="import"
-	      static="true"
-	      descriptor="()Ltensorflow;">
-        <new def="x" class="Lturtle"/>
- 	<putfield class="Lturtle"
-                  field="any"
-                  fieldType="LRoot"
-                  ref="x"
-                  value="x"/>
-        <return value="x"/>
+      <method name="import" static="true" descriptor="()Ltensorflow;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
       </method>
     </class>
   </classloader>

--- a/pom.xml
+++ b/pom.xml
@@ -151,8 +151,11 @@
               </format>
               <format>
                 <includes>
-                  <include>*.xml</include>
+                  <include>**/*.xml</include>
                 </includes>
+                <excludes>
+                  <exclude>**/plugin.xml</exclude>
+                </excludes>
                 <eclipseWtp>
                   <type>XML</type>
                   <files>

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
                 <excludes>
                   <exclude>**/plugin.xml</exclude>
                   <exclude>pom.xml</exclude>
+                  <exclude>./jython3/dist/Lib/test/xmltestdata/test.xml</exclude>
                 </excludes>
                 <eclipseWtp>
                   <type>XML</type>

--- a/pom.xml
+++ b/pom.xml
@@ -139,8 +139,8 @@
             <formats>
               <format>
                 <includes>
-                  <include>*.md</include>
-                  <include>.gitignore</include>
+                  <include>**/*.md</include>
+                  <include>**/.gitignore</include>
                 </includes>
                 <trimTrailingWhitespace/>
                 <endWithNewline/>

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,7 @@
                 </includes>
                 <excludes>
                   <exclude>**/plugin.xml</exclude>
+                  <exclude>pom.xml</exclude>
                 </excludes>
                 <eclipseWtp>
                   <type>XML</type>

--- a/pom.xml
+++ b/pom.xml
@@ -142,8 +142,8 @@
                   <include>*.md</include>
                   <include>.gitignore</include>
                 </includes>
-                <trimTrailingWhitespace />
-                <endWithNewline />
+                <trimTrailingWhitespace/>
+                <endWithNewline/>
                 <indent>
                   <tabs>true</tabs>
                   <spacesPerTab>4</spacesPerTab>
@@ -180,7 +180,7 @@
               <includes>
                 <include>*.py</include>
               </includes>
-              <black />
+              <black/>
             </python>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
                 <excludes>
                   <exclude>**/plugin.xml</exclude>
                   <exclude>pom.xml</exclude>
-                  <exclude>/home/runner/work/ML/ML/jython3/dist/Lib/test/xmltestdata/test.xml</exclude>
+                  <exclude>./jython3/dist/Lib/test/xmltestdata/test.xml</exclude>
                 </excludes>
                 <eclipseWtp>
                   <type>XML</type>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,6 @@
                 <excludes>
                   <exclude>**/plugin.xml</exclude>
                   <exclude>pom.xml</exclude>
-                  <exclude>./jython3/dist/Lib/test/xmltestdata/test.xml</exclude>
                 </excludes>
                 <eclipseWtp>
                   <type>XML</type>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
                 <excludes>
                   <exclude>**/plugin.xml</exclude>
                   <exclude>pom.xml</exclude>
-                  <exclude>./jython3/dist/Lib/test/xmltestdata/test.xml</exclude>
+                  <exclude>/home/runner/work/ML/ML/jython3/dist/Lib/test/xmltestdata/test.xml</exclude>
                 </excludes>
                 <eclipseWtp>
                   <type>XML</type>


### PR DESCRIPTION
1. XML formatting was not recursing into subdirectories. Fixed.
1. GitHub Actions CI config was not maintaining the correct working directories. Fixed.
1. Use `git clone` directly to avoid XML formatting error in external dependencies by cloning into a temporary directory outside the project directory.
1. Also recurse into subdirectories for other metadata files.