### PR TITLE
Add missing type check before cast in TF model parsing test (small change)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModelParsing.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModelParsing.java
@@ -22,10 +22,13 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.junit.Test;
 
 public class TestTensorflowModelParsing extends TestPythonMLCallGraphShape {
+
+  private static final Logger logger = Logger.getLogger(TestTensorflowModelParsing.class.getName());
 
   /** Test a parsing bug (see https://github.com/wala/ML/pull/46#issue-1743032519). */
   @Test
@@ -53,23 +56,27 @@ public class TestTensorflowModelParsing extends TestPythonMLCallGraphShape {
     analysis.forEach(
         p -> {
           PointerKey pointerKey = p.fst;
-          LocalPointerKey localPointerKey = (LocalPointerKey) pointerKey;
 
-          // get the call graph node associated with the
-          CGNode node = localPointerKey.getNode();
+          if (pointerKey instanceof LocalPointerKey) {
+            LocalPointerKey localPointerKey = (LocalPointerKey) pointerKey;
 
-          // get the method associated with the call graph node.
-          IMethod method = node.getMethod();
-          String methodSignature = method.getSignature();
+            // get the call graph node associated with the
+            CGNode node = localPointerKey.getNode();
 
-          // associate the method to the pointer key.
-          methodSignatureToPointerKeys.compute(
-              methodSignature,
-              (k, v) -> {
-                if (v == null) v = new HashSet<>();
-                v.add(localPointerKey);
-                return v;
-              });
+            // get the method associated with the call graph node.
+            IMethod method = node.getMethod();
+            String methodSignature = method.getSignature();
+
+            // associate the method to the pointer key.
+            methodSignatureToPointerKeys.compute(
+                methodSignature,
+                (k, v) -> {
+                  if (v == null) v = new HashSet<>();
+                  v.add(localPointerKey);
+                  return v;
+                });
+          } else
+            logger.warning(() -> "Encountered pointer key type: " + pointerKey.getClass() + ".");
         });
 
     // we should have two methods.


### PR DESCRIPTION
Small fix to check a cast in the test code. This is a small change, but a larger fix that we are preparing will depend on it.