### PR TITLE
Add concurrency clause to GitHub Actions CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,6 +4,9 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Cancel in-progress builds when a new commit is pushed. From https://github.com/wala/WALA/blob/89de874efbc3369097e03b85493f4a3beb8e1a44/.github/workflows/continuous-integration.yml#L7-L9.