### PR TITLE
Using XML summaries to add some TF2 APIs

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -103,7 +103,7 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     testTf2("tf2p2.py", "value_index", 2, 4, 2, 3);
     testTf2("tf2q.py", "add", 2, 3, 2, 3);
     testTf2("tf2r.py", "add", 2, 3, 2, 3);
-    // TODO: Uncomment below test when https://github.com/ponder-lab/ML/issues/34 is fixed.
+    // TODO: Uncomment below test when https://github.com/wala/ML/issues/65 is fixed.
     // testTf2("tf2s.py", "add", 2, 3, 2, 3);
   }
 

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -37,11 +37,12 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     PythonSSAPropagationCallGraphBuilder builder = E.defaultCallGraphBuilder();
     CallGraph CG = builder.makeCallGraph(builder.getOptions());
 
-    //		CAstCallGraphUtil.AVOID_DUMP = false;
+    // CAstCallGraphUtil.AVOID_DUMP = false;
     //
-    //	CAstCallGraphUtil.dumpCG(((SSAPropagationCallGraphBuilder)builder).getCFAContextInterpreter(), builder.getPointerAnalysis(), CG);
+    // CAstCallGraphUtil.dumpCG(((SSAPropagationCallGraphBuilder)builder).getCFAContextInterpreter(),
+    // builder.getPointerAnalysis(), CG);
 
-    //		System.err.println(CG);
+    // System.err.println(CG);
 
     Collection<CGNode> nodes = getNodes(CG, "script tf1.py/model_fn");
     assert !nodes.isEmpty() : "model_fn should be called";
@@ -62,30 +63,56 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
   @Test
   public void testTf2()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    testTf2("tf2.py", "add", 2, 2, 3);
-    testTf2("tf2b.py", "add", 2, 2, 3);
-    testTf2("tf2c.py", "add", 2, 2, 3);
-    testTf2("tf2d.py", "add", 2, 2, 3);
-    testTf2("tf2e.py", "add", 2, 2, 3);
-    testTf2("tf2f.py", "add", 2, 2, 3);
-    testTf2("tf2g.py", "add", 2, 2, 3);
-    testTf2("tf2h.py", "add", 2, 2, 3);
-    testTf2("tf2i.py", "add", 2, 2, 3);
-    testTf2("tf2j.py", "add", 2, 2, 3);
-    testTf2("tf2k.py", "add", 2, 2, 3);
-    testTf2("tf2l.py", "add", 2, 2, 3);
-    testTf2("tf2m.py", "add", 2, 2, 3);
-    // TODO: Uncomment below test when https://github.com/wala/ML/issues/49 is fixed.
-    // testTf2("tf2n.py", "func2", 1, 2);
-    testTf2("tf2o.py", "add", 2, 2, 3);
-    testTf2("tf2p.py", "value_index", 2, 2, 3);
+    testTf2("tf2.py", "add", 2, 3, 2, 3);
+    testTf2("tf2b.py", "add", 2, 3, 2, 3);
+    testTf2("tf2c.py", "add", 2, 4, 2, 3);
+    testTf2("tf2d.py", "add", 2, 3, 2, 3);
+    testTf2("tf2d2.py", "add", 2, 3, 2, 3);
+    testTf2("tf2d3.py", "add", 2, 3, 2, 3);
+    testTf2("tf2d4.py", "add", 2, 4, 2, 3);
+    testTf2("tf2e.py", "add", 2, 3, 2, 3);
+    testTf2("tf2e2.py", "add", 2, 4, 2, 3);
+    testTf2("tf2e3.py", "add", 2, 3, 2, 3);
+    testTf2("tf2e4.py", "add", 2, 4, 2, 3);
+    testTf2("tf2e5.py", "add", 2, 3, 2, 3);
+    testTf2("tf2e6.py", "add", 2, 3, 2, 3);
+    testTf2("tf2e7.py", "add", 2, 3, 2, 3);
+    testTf2("tf2f.py", "add", 2, 3, 2, 3);
+    testTf2("tf2f2.py", "add", 2, 4, 2, 3);
+    testTf2("tf2f3.py", "add", 2, 4, 2, 3);
+    testTf2("tf2g.py", "add", 2, 3, 2, 3);
+    testTf2("tf2g2.py", "add", 2, 4, 2, 3);
+    testTf2("tf2h.py", "add", 2, 3, 2, 3);
+    testTf2("tf2h2.py", "add", 2, 4, 2, 3);
+    testTf2("tf2i.py", "add", 2, 3, 2, 3);
+    testTf2("tf2i2.py", "add", 2, 4, 2, 3);
+    testTf2("tf2j.py", "add", 2, 3, 2, 3);
+    testTf2("tf2j2.py", "add", 2, 4, 2, 3);
+    testTf2("tf2k.py", "add", 2, 3, 2, 3);
+    testTf2("tf2k2.py", "add", 2, 4, 2, 3);
+    testTf2("tf2l.py", "add", 2, 3, 2, 3);
+    testTf2("tf2l2.py", "add", 2, 4, 2, 3);
+    testTf2("tf2m.py", "add", 2, 3, 2, 3);
+    testTf2("tf2m2.py", "add", 2, 4, 2, 3);
+    testTf2("tf2n.py", "func2", 1, 4, 2);
+    testTf2("tf2n2.py", "func2", 1, 4, 2);
+    testTf2("tf2n3.py", "func2", 1, 4, 2);
+    testTf2("tf2o.py", "add", 2, 3, 2, 3);
+    testTf2("tf2o2.py", "add", 2, 4, 2, 3);
+    testTf2("tf2p.py", "value_index", 2, 4, 2, 3);
+    testTf2("tf2p2.py", "value_index", 2, 4, 2, 3);
+    testTf2("tf2q.py", "add", 2, 3, 2, 3);
+    testTf2("tf2r.py", "add", 2, 3, 2, 3);
+    // TODO: Uncomment below test when https://github.com/ponder-lab/ML/issues/34 is fixed.
+    // testTf2("tf2s.py", "add", 2, 3, 2, 3);
   }
 
   private void testTf2(
       String filename,
       String functionName,
       int expectedNumberOfTensorParameters,
-      int... expectedValueNumbers)
+      int expectedNumberOfTensorVariables,
+      int... expectedTensorParameterValueNumbers)
       throws ClassHierarchyException, CancelException, IOException {
     PythonAnalysisEngine<TensorTypeAnalysis> E = makeEngine(filename);
     PythonSSAPropagationCallGraphBuilder builder = E.defaultCallGraphBuilder();
@@ -93,11 +120,10 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     CallGraph CG = builder.makeCallGraph(builder.getOptions());
     assertNotNull(CG);
 
-    //		CAstCallGraphUtil.AVOID_DUMP = false;
-    //		CAstCallGraphUtil.dumpCG(builder.getCFAContextInterpreter(), builder.getPointerAnalysis(),
-    // CG);
-
-    //		System.err.println(CG);
+    // CAstCallGraphUtil.AVOID_DUMP = false;
+    // CAstCallGraphUtil.dumpCG(((SSAPropagationCallGraphBuilder)builder).getCFAContextInterpreter(),
+    // builder.getPointerAnalysis(), CG);
+    // System.err.println(CG);
 
     TensorTypeAnalysis analysis = E.performAnalysis(builder);
 
@@ -145,8 +171,8 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
         });
 
     // check the maps.
-    assertEquals(expectedNumberOfTensorParameters, methodSignatureToPointerKeys.size());
-    assertEquals(expectedNumberOfTensorParameters, methodSignatureToTensorVariables.size());
+    assertEquals(expectedNumberOfTensorVariables, methodSignatureToPointerKeys.size());
+    assertEquals(expectedNumberOfTensorVariables, methodSignatureToTensorVariables.size());
 
     final String functionSignature = "script " + filename + "." + functionName + ".do()LRoot;";
 
@@ -162,8 +188,9 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
             .map(LocalPointerKey::getValueNumber)
             .collect(Collectors.toSet());
 
-    assertEquals(expectedValueNumbers.length, actualValueNumberSet.size());
-    Arrays.stream(expectedValueNumbers).forEach(ev -> actualValueNumberSet.contains(ev));
+    assertEquals(expectedTensorParameterValueNumbers.length, actualValueNumberSet.size());
+    Arrays.stream(expectedTensorParameterValueNumbers)
+        .forEach(ev -> actualValueNumberSet.contains(ev));
 
     // get the tensor variables for the function.
     Set<TensorVariable> functionTensors = methodSignatureToTensorVariables.get(functionSignature);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModelParsing.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModelParsing.java
@@ -41,11 +41,11 @@ public class TestTensorflowModelParsing extends TestPythonMLCallGraphShape {
     CallGraph CG = builder.makeCallGraph(builder.getOptions());
     assertNotNull(CG);
 
-    //		CAstCallGraphUtil.AVOID_DUMP = false;
-    //		CAstCallGraphUtil.dumpCG(builder.getCFAContextInterpreter(), builder.getPointerAnalysis(),
+    // CAstCallGraphUtil.AVOID_DUMP = false;
+    // CAstCallGraphUtil.dumpCG(builder.getCFAContextInterpreter(), builder.getPointerAnalysis(),
     // CG);
 
-    //		System.err.println(CG);
+    // System.err.println(CG);
 
     TensorTypeAnalysis analysis = E.performAnalysis(builder);
 
@@ -79,8 +79,8 @@ public class TestTensorflowModelParsing extends TestPythonMLCallGraphShape {
             logger.warning(() -> "Encountered pointer key type: " + pointerKey.getClass() + ".");
         });
 
-    // we should have two methods.
-    assertEquals(2, methodSignatureToPointerKeys.size());
+    // we should have 3 methods.
+    assertEquals(3, methodSignatureToPointerKeys.size());
 
     final String addFunctionSignature = "script " + filename + ".add.do()LRoot;";
 

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -37,6 +37,8 @@
         <putfield class="LRoot" field="nn" fieldType="LRoot" ref="x" value="nn" />
         <new def="layers" class="Lobject" />
         <putfield class="LRoot" field="layers" fieldType="LRoot" ref="x" value="layers" />
+        <new def="random" class="Lobject" />
+        <putfield class="LRoot" field="random" fieldType="LRoot" ref="x" value="random" />
 
         <new def="app" class="Lobject" />
         <putfield class="LRoot" field="app" fieldType="LRoot" ref="x" value="app" />
@@ -55,6 +57,45 @@
         <new def="reshape" class="Ltensorflow/functions/reshape" />
         <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="x" value="reshape" />
 
+        <new def="ones" class="Ltensorflow/functions/ones" />
+        <putfield class="LRoot" field="ones" fieldType="LRoot" ref="x" value="ones" />
+
+        <new def="Variable" class="Ltensorflow/functions/Variable" />
+        <putfield class="LRoot" field="Variable" fieldType="LRoot" ref="x" value="Variable" />
+
+        <new def="constant" class="Ltensorflow/functions/constant" />
+        <putfield class="LRoot" field="constant" fieldType="LRoot" ref="x" value="constant" />
+
+        <new def="zeros" class="Ltensorflow/functions/zeros" />
+        <putfield class="LRoot" field="zeros" fieldType="LRoot" ref="x" value="zeros" />
+
+        <new def="SparseTensor" class="Ltensorflow/functions/SparseTensor" />
+        <putfield class="LRoot" field="SparseTensor" fieldType="LRoot" ref="x" value="SparseTensor" />
+
+        <new def="fill" class="Ltensorflow/functions/fill" />
+        <putfield class="LRoot" field="fill" fieldType="LRoot" ref="x" value="fill" />
+
+        <new def="zeros_like" class="Ltensorflow/functions/zeros_like" />
+        <putfield class="LRoot" field="zeros_like" fieldType="LRoot" ref="x" value="zeros_like" />
+
+        <new def="one_hot" class="Ltensorflow/functions/one_hot" />
+        <putfield class="LRoot" field="one_hot" fieldType="LRoot" ref="x" value="one_hot" />
+
+        <new def="convert_to_tensor" class="Ltensorflow/functions/convert_to_tensor" />
+        <putfield class="LRoot" field="convert_to_tensor" fieldType="LRoot" ref="x" value="convert_to_tensor" />
+
+        <new def="range" class="Ltensorflow/functions/range" />
+        <putfield class="LRoot" field="range" fieldType="LRoot" ref="x" value="range" />
+
+        <new def="Tensor" class="Ltensorflow/functions/Tensor" />
+        <putfield class="LRoot" field="Tensor" fieldType="LRoot" ref="x" value="Tensor" />
+
+        <new def="eye" class="Ltensorflow/functions/eye" />
+        <putfield class="LRoot" field="eye" fieldType="LRoot" ref="x" value="eye" />
+
+        <new def="uniform" class="Ltensorflow/functions/uniform" />
+        <putfield class="LRoot" field="uniform" fieldType="LRoot" ref="random" value="uniform" />
+
         <new def="conv2d" class="Ltensorflow/functions/conv2d" />
         <putfield class="LRoot" field="conv2d" fieldType="LRoot" ref="x" value="conv2d" />
         <putfield class="LRoot" field="conv2d" fieldType="LRoot" ref="nn" value="conv2d" />
@@ -68,14 +109,90 @@
 
         <new def="examples" class="Lobject" />
         <putfield class="LRoot" field="examples" fieldType="LRoot" ref="x" value="examples" />
+
         <new def="tutorials" class="Lobject" />
         <putfield class="LRoot" field="tutorials" fieldType="LRoot" ref="examples" value="tutorials" />
+
         <new def="mnist" class="Lobject" />
         <putfield class="LRoot" field="mnist" fieldType="LRoot" ref="tutorials" value="mnist" />
+
         <new def="id" class="Ltensorflow/examples/tutorials/mnist/input_data" />
         <putfield class="LRoot" field="input_data" fieldType="LRoot" ref="mnist" value="id" />
+
         <new def="rds" class="Ltensorflow/examples/tutorials/mnist/read_data_sets" />
         <putfield class="LRoot" field="read_data_sets" fieldType="LRoot" ref="id" value="rds" />
+
+        <new def="python" class="Lobject" />
+        <putfield class="LRoot" field="python" fieldType="LRoot" ref="x" value="python" />
+
+        <new def="ops" class="Lobject" />
+        <putfield class="LRoot" field="ops" fieldType="LRoot" ref="python" value="ops" />
+
+        <new def="framework" class="Lobject" />
+        <putfield class="LRoot" field="framework" fieldType="LRoot" ref="python" value="framework" />
+
+        <new def="array_ops" class="Lobject" />
+        <putfield class="LRoot" field="array_ops" fieldType="LRoot" ref="ops" value="array_ops" />
+
+        <new def="random_ops" class="Lobject" />
+        <putfield class="LRoot" field="random_ops" fieldType="LRoot" ref="ops" value="random_ops" />
+
+        <new def="math_ops" class="Lobject" />
+        <putfield class="LRoot" field="math_ops" fieldType="LRoot" ref="ops" value="math_ops" />
+
+        <new def="linalg_ops" class="Lobject" />
+        <putfield class="LRoot" field="linalg_ops" fieldType="LRoot" ref="ops" value="linalg_ops" />
+
+        <new def="variables" class="Lobject" />
+        <putfield class="LRoot" field="variables" fieldType="LRoot" ref="ops" value="variables" />
+
+        <new def="ops2" class="Lobject" />
+        <putfield class="LRoot" field="ops" fieldType="LRoot" ref="framework" value="ops2" />
+
+        <new def="sparse_tensor" class="Lobject" />
+        <putfield class="LRoot" field="sparse_tensor" fieldType="LRoot" ref="framework" value="sparse_tensor" />
+
+        <new def="constant_op" class="Lobject" />
+        <putfield class="LRoot" field="constant_op" fieldType="LRoot" ref="framework" value="constant_op" />
+
+        <new def="fqn_Variable" class="Ltensorflow/python/ops/variables/Variable" />
+        <putfield class="LRoot" field="Variable" fieldType="LRoot" ref="variables" value="fqn_Variable" />
+
+        <new def="fqn_ones" class="Ltensorflow/python/ops/array_ops/ones" />
+        <putfield class="LRoot" field="ones" fieldType="LRoot" ref="array_ops" value="fqn_ones" />
+
+        <new def="fqn_zeros" class="Ltensorflow/python/ops/array_ops/zeros" />
+        <putfield class="LRoot" field="zeros" fieldType="LRoot" ref="array_ops" value="fqn_zeros" />
+
+        <new def="fqn_fill" class="Ltensorflow/python/ops/array_ops/fill" />
+        <putfield class="LRoot" field="fill" fieldType="LRoot" ref="array_ops" value="fqn_fill" />
+
+        <new def="fqn_zeros_like" class="Ltensorflow/python/ops/array_ops/zeros_like" />
+        <putfield class="LRoot" field="zeros_like" fieldType="LRoot" ref="array_ops" value="fqn_zeros_like" />
+
+        <new def="fqn_one_hot" class="Ltensorflow/python/ops/array_ops/one_hot" />
+        <putfield class="LRoot" field="one_hot" fieldType="LRoot" ref="array_ops" value="fqn_one_hot" />
+
+        <new def="fqn_random_uniform" class="Ltensorflow/python/ops/random_ops/random_uniform" />
+        <putfield class="LRoot" field="random_uniform" fieldType="LRoot" ref="random_ops" value="fqn_ones" />
+
+        <new def="fqn_range" class="Ltensorflow/python/ops/math_ops/range" />
+        <putfield class="LRoot" field="range" fieldType="LRoot" ref="math_ops" value="fqn_range" />
+
+        <new def="fqn_eye" class="Ltensorflow/python/ops/linalg_ops/eye" />
+        <putfield class="LRoot" field="eye" fieldType="LRoot" ref="linalg_ops" value="fqn_eye" />
+
+        <new def="fqn_constant" class="Ltensorflow/python/framework/constant_op/constant" />
+        <putfield class="LRoot" field="constant" fieldType="LRoot" ref="constant_op" value="fqn_constant" />
+
+        <new def="fqn_SparseTensor" class="Ltensorflow/python/framework/sparse_tensor/SparseTensor" />
+        <putfield class="LRoot" field="SparseTensor" fieldType="LRoot" ref="sparse_tensor" value="fqn_SparseTensor" />
+
+        <new def="fqn_convert_to_tensor" class="Ltensorflow/python/framework/ops/convert_to_tensor" />
+        <putfield class="LRoot" field="convert_to_tensor" fieldType="LRoot" ref="ops2" value="fqn_convert_to_tensor" />
+
+        <new def="fqn_Tensor" class="Ltensorflow/python/framework/ops/Tensor" />
+        <putfield class="LRoot" field="Tensor" fieldType="LRoot" ref="ops2" value="fqn_Tensor" />
 
         <return value="x" />
       </method>
@@ -142,6 +259,149 @@
 
         <method name="do" descriptor="()LRoot;" numArgs="3">
           <call class="LRoot" name="copy_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+
+      <class name="ones" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/ops/array_ops/ones" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="shape dtype name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+
+      <class name="Variable" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/ops/variables/Variable" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="12" paramNames="initial_value trainable validate_shape caching_device name variable_def dtype import_scope constraint synchronization aggregation shape">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+
+      <class name="constant" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/framework/constant_op/constant" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="value dtype shape name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+
+      <class name="zeros" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/ops/array_ops/zeros" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="shape dtype name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+
+      <class name="SparseTensor" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/framework/sparse_tensor/SparseTensor" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="indices values dense_shape">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+
+      <class name="fill" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/ops/array_ops/fill" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="dims value name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+
+      <class name="zeros_like" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/ops/array_ops/zeros_like" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="input dtype name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+
+      <class name="one_hot" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/ops/array_ops/one_hot" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="indices depth on_value off_value axis dtype name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+
+      <class name="convert_to_tensor" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/framework/ops/convert_to_tensor" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="value dtype dtype_hint name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+
+      <class name="range" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/ops/math_ops/range" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="limit delta dtype name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+
+      <class name="Tensor" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="op value_index dtype">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+
+      <class name="eye" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/ops/linalg_ops/eye" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="num_rows num_columns batch_shape dtype name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+
+      <class name="uniform" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/ops/random_ops/uniform" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="shape minval maxval dtype seed name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
           <return value="x" />
         </method>
       </class>
@@ -258,6 +518,160 @@
       <class name="input_data" allocatable="true">
       </class>
       <class name="dataset" allocatable="true">
+      </class>
+    </package>
+
+    <package name="tensorflow/python/ops/array_ops">
+      <class name="ones" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/ops/array_ops/ones" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="shape dtype name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+      <class name="zeros" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/ops/array_ops/zeros" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="shape dtype name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+      <class name="fill" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/ops/array_ops/fill" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="dims value name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+      <class name="zeros_like" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/ops/array_ops/zeros_like" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="input dtype name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+      <class name="one_hot" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/ops/array_ops/one_hot" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="indices depth on_value off_value axis dtype name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+    </package>
+
+    <package name="tensorflow/python/ops/random_ops">
+      <class name="random_uniform" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/ops/random_ops/random_uniform" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="shape minval maxval dtype seed name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+    </package>
+
+    <package name="tensorflow/python/ops/math_ops">
+      <class name="range" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/ops/math_ops/range" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="limit delta dtype name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+    </package>
+
+    <package name="tensorflow/python/ops/linalg_ops">
+      <class name="eye" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/ops/linalg_ops/eye" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="num_rows num_columns batch_shape dtype name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+    </package>
+
+    <package name="tensorflow/python/ops/variables">
+      <class name="Variable" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/ops/variables/Variable" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="12" paramNames="initial_value trainable validate_shape caching_device name variable_def dtype import_scope constraint synchronization aggregation shape">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+    </package>
+
+    <package name="tensorflow/python/framework/constant_op">
+      <class name="constant" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/framework/constant_op/constant" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="value dtype shape name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+    </package>
+
+    <package name="tensorflow/python/framework/sparse_tensor">
+      <class name="SparseTensor" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/framework/sparse_tensor/SparseTensor" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="indices values dense_shape">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+    </package>
+
+    <package name="tensorflow/python/framework/ops">
+      <class name="convert_to_tensor" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/framework/ops/convert_to_tensor" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="value dtype dtype_hint name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
+      </class>
+      <class name="Tensor" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="op value_index dtype">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
+        </method>
       </class>
     </package>
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1,6 +1,5 @@
 package com.ibm.wala.cast.python.ml.client;
 
-import com.google.common.base.Objects;
 import com.ibm.wala.cast.lsp.AnalysisError;
 import com.ibm.wala.cast.python.client.PythonAnalysisEngine;
 import com.ibm.wala.cast.python.ir.PythonLanguage;
@@ -18,11 +17,9 @@ import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.ssa.DefUse;
-import com.ibm.wala.ssa.IR;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.ssa.SSAInvokeInstruction;
-import com.ibm.wala.ssa.Value;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.Selector;
 import com.ibm.wala.types.TypeName;
@@ -34,9 +31,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.graph.Graph;
 import com.ibm.wala.util.graph.impl.SlowSparseNumberedGraph;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.Map;
-import java.util.Queue;
 import java.util.Set;
 
 public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeAnalysis> {
@@ -88,84 +83,14 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       if (k instanceof LocalPointerKey) {
         LocalPointerKey kk = (LocalPointerKey) k;
         int vn = kk.getValueNumber();
-        CGNode node = kk.getNode();
-        DefUse du = node.getDU();
+        DefUse du = kk.getNode().getDU();
         SSAInstruction inst = du.getDef(vn);
 
         if (inst instanceof SSAAbstractInvokeInstruction) {
           SSAAbstractInvokeInstruction ni = (SSAAbstractInvokeInstruction) inst;
 
-          // A queue of API calls starting from the right-most API from the selection operator,
-          // e.g., tf.random.uniform.
-          Queue<String> tensorFlowAPIQueue = new LinkedList<>();
-
-          if (!ni.isStatic()) {
-            int receiver = ni.getReceiver();
-            SSAInstruction receiverDefinition = du.getDef(receiver);
-
-            if (receiverDefinition instanceof PythonPropertyRead) {
-              PythonPropertyRead propertyRead = (PythonPropertyRead) receiverDefinition;
-
-              // are we calling a TensorFlow API?
-              if (isFromTensorFlow(propertyRead, du)) {
-                int memberRef = propertyRead.getMemberRef();
-                SSAInstruction memberRefDefinition = du.getDef(memberRef);
-
-                // if the member reference can't be found.
-                if (memberRefDefinition == null) {
-                  // look it up in the IR.
-                  IR ir = node.getIR();
-                  Value memberRefValue = ir.getSymbolTable().getValue(memberRef);
-
-                  // while a member ref value exists and it's a string constant.
-                  while (memberRefValue != null && memberRefValue.isStringConstant()) {
-                    // push the API onto the queue.
-                    tensorFlowAPIQueue.add(ir.getSymbolTable().getStringValue(memberRef));
-
-                    // go back one "level."
-                    memberRefValue = ir.getSymbolTable().getValue(--memberRef);
-                  }
-                }
-              }
-            }
-          }
-
-          // process the API "levels."
-          if (ni.getException() != vn) {
-            if (!tensorFlowAPIQueue.isEmpty()) {
-              // pop the first element.
-              String tensorFlowAPI = tensorFlowAPIQueue.remove();
-
-              // Single-level APIs.
-              if (Objects.equal(tensorFlowAPI, "ones")
-                  || Objects.equal(tensorFlowAPI, "Variable")
-                  || Objects.equal(tensorFlowAPI, "zeros")
-                  || Objects.equal(tensorFlowAPI, "constant")
-                  || Objects.equal(tensorFlowAPI, "SparseTensor")
-                  || Objects.equal(tensorFlowAPI, "Tensor")
-                  || Objects.equal(tensorFlowAPI, "fill")
-                  || Objects.equal(tensorFlowAPI, "eye")
-                  || Objects.equal(tensorFlowAPI, "zeros_like")
-                  || Objects.equal(tensorFlowAPI, "one_hot")
-                  || Objects.equal(tensorFlowAPI, "convert_to_tensor")
-                  || Objects.equal(tensorFlowAPI, "range")) sources.add(src);
-              // Double-level APIs.
-              else if (Objects.equal(tensorFlowAPI, "uniform")) {
-                // Check the next "level".
-                if (tensorFlowAPIQueue.isEmpty())
-                  // not expecting this API call.
-                  throw new IllegalStateException("Encountered unexpected API call.");
-
-                tensorFlowAPI = tensorFlowAPIQueue.remove();
-
-                if (Objects.equal(tensorFlowAPI, "random")) sources.add(src);
-              }
-            } else if (ni.getCallSite()
-                .getDeclaredTarget()
-                .getName()
-                .toString()
-                .equals("read_data")) sources.add(src);
-          }
+          if (ni.getCallSite().getDeclaredTarget().getName().toString().equals("read_data")
+              && ni.getException() != vn) sources.add(src);
         }
       }
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -2,10 +2,8 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.lsp.AnalysisError;
 import com.ibm.wala.cast.python.client.PythonAnalysisEngine;
-import com.ibm.wala.cast.python.ir.PythonLanguage;
 import com.ibm.wala.cast.python.ml.analysis.TensorTypeAnalysis;
 import com.ibm.wala.cast.python.ml.types.TensorType;
-import com.ibm.wala.cast.python.ssa.PythonPropertyRead;
 import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.cast.types.AstMethodReference;
 import com.ibm.wala.classLoader.CallSiteReference;
@@ -19,9 +17,7 @@ import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.ssa.DefUse;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
-import com.ibm.wala.ssa.SSAInvokeInstruction;
 import com.ibm.wala.types.MethodReference;
-import com.ibm.wala.types.Selector;
 import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
@@ -67,12 +63,6 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
               TypeName.string2TypeName("Ltensorflow/functions/set_shape")),
           AstMethodReference.fnSelector);
 
-  private static final MethodReference import_tensorflow =
-      MethodReference.findOrCreate(
-          TypeReference.findOrCreate(
-              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow")),
-          Selector.make(PythonLanguage.Python, "import()Ltensorflow;"));
-
   private final Map<PointerKey, AnalysisError> errorLog = HashMapFactory.make();
 
   private static Set<PointsToSetVariable> getDataflowSources(Graph<PointsToSetVariable> dataflow) {
@@ -95,29 +85,6 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       }
     }
     return sources;
-  }
-
-  /**
-   * True iff the given {@link PythonPropertyRead} corresponds to a TensorFlow API invocation.
-   *
-   * @param propertyRead The {@link PythonPropertyRead} to check.
-   * @param du The {@link DefUse} from the corresponding {@link CGNode}.
-   * @return True iff the given {@link PythonPropertyRead} corresponds to a TensorFlow API
-   *     invocation.
-   */
-  private static boolean isFromTensorFlow(PythonPropertyRead propertyRead, DefUse du) {
-    int objectRef = propertyRead.getObjectRef();
-    SSAInstruction objectRefDefinition = du.getDef(objectRef);
-
-    if (objectRefDefinition instanceof SSAInvokeInstruction) {
-      SSAInvokeInstruction objectRefInvocInstruction = (SSAInvokeInstruction) objectRefDefinition;
-      MethodReference objectRefInvocationDeclaredTarget =
-          objectRefInvocInstruction.getDeclaredTarget();
-      return objectRefInvocationDeclaredTarget.equals(import_tensorflow);
-    } else if (objectRefDefinition instanceof PythonPropertyRead)
-      // it's an import tree. Dig deeper to find the root.
-      return isFromTensorFlow((PythonPropertyRead) objectRefDefinition, du);
-    return false;
   }
 
   @FunctionalInterface

--- a/com.ibm.wala.cast.python.test/data/tf2d.py
+++ b/com.ibm.wala.cast.python.test/data/tf2d.py
@@ -1,7 +1,8 @@
 import tensorflow as tf
+import tensorflow
 
 def add(a, b):
   return a + b
 
 
-c = add(tf.random.uniform([1, 2]), tf.random.uniform([2, 2]))
+c = add(tf.random.uniform([1, 2]), tensorflow.random.uniform([2, 2]))

--- a/com.ibm.wala.cast.python.test/data/tf2d2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2d2.py
@@ -1,0 +1,8 @@
+import tensorflow as tf
+from tensorflow import random
+
+def add(a, b):
+  return a + b
+
+
+c = add(tf.random.uniform([1, 2]), random.uniform([2, 2]))

--- a/com.ibm.wala.cast.python.test/data/tf2d3.py
+++ b/com.ibm.wala.cast.python.test/data/tf2d3.py
@@ -1,0 +1,8 @@
+from tensorflow import random
+from tensorflow.random import uniform
+
+def add(a, b):
+  return a + b
+
+
+c = add(uniform([1, 2]), random.uniform([2, 2]))

--- a/com.ibm.wala.cast.python.test/data/tf2d4.py
+++ b/com.ibm.wala.cast.python.test/data/tf2d4.py
@@ -1,0 +1,8 @@
+from tensorflow.random import uniform
+from tensorflow.python.ops.random_ops import random_uniform
+
+def add(a, b):
+  return a + b
+
+
+c = add(uniform([1, 2]), random_uniform([2, 2]))

--- a/com.ibm.wala.cast.python.test/data/tf2e2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2e2.py
@@ -1,5 +1,5 @@
 import tensorflow as tf
-from tensorflow import Variable
+from tensorflow.python.ops.variables import Variable
 
 def add(a, b):
   return a + b

--- a/com.ibm.wala.cast.python.test/data/tf2e3.py
+++ b/com.ibm.wala.cast.python.test/data/tf2e3.py
@@ -1,0 +1,6 @@
+import tensorflow
+def add(a, b):
+  return a + b
+
+
+c = add(tensorflow.Variable([1., 2.]), tensorflow.Variable([2., 2.]))

--- a/com.ibm.wala.cast.python.test/data/tf2e4.py
+++ b/com.ibm.wala.cast.python.test/data/tf2e4.py
@@ -1,0 +1,8 @@
+import tensorflow as tensors
+from tensorflow.python.ops.variables import Variable
+
+def add(a, b):
+  return a + b
+
+
+c = add(tensors.Variable([1., 2.]), Variable([2., 2.]))

--- a/com.ibm.wala.cast.python.test/data/tf2e5.py
+++ b/com.ibm.wala.cast.python.test/data/tf2e5.py
@@ -1,0 +1,7 @@
+from tensorflow.python.ops import variables
+
+def add(a, b):
+  return a + b
+
+
+c = add(variables.Variable([1., 2.]), variables.Variable([2., 2.]))

--- a/com.ibm.wala.cast.python.test/data/tf2e6.py
+++ b/com.ibm.wala.cast.python.test/data/tf2e6.py
@@ -1,0 +1,7 @@
+from tensorflow.python import ops
+
+def add(a, b):
+  return a + b
+
+
+c = add(ops.variables.Variable([1., 2.]), ops.variables.Variable([2., 2.]))

--- a/com.ibm.wala.cast.python.test/data/tf2e7.py
+++ b/com.ibm.wala.cast.python.test/data/tf2e7.py
@@ -1,0 +1,7 @@
+from tensorflow import python
+
+def add(a, b):
+  return a + b
+
+
+c = add(python.ops.variables.Variable([1., 2.]), python.ops.variables.Variable([2., 2.]))

--- a/com.ibm.wala.cast.python.test/data/tf2f2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2f2.py
@@ -1,0 +1,7 @@
+import tensorflow
+from tensorflow.python.framework.constant_op import constant
+def add(a, b):
+  return a + b
+
+
+c = add(tensorflow.constant([1, 2]), constant([2, 2]))

--- a/com.ibm.wala.cast.python.test/data/tf2f3.py
+++ b/com.ibm.wala.cast.python.test/data/tf2f3.py
@@ -1,0 +1,7 @@
+import tensorflow as tf
+from tensorflow.python.framework.constant_op import constant
+def add(a, b):
+  return a + b
+
+
+c = add(tf.constant([1, 2]), constant([2, 2]))

--- a/com.ibm.wala.cast.python.test/data/tf2g2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2g2.py
@@ -1,0 +1,8 @@
+import tensorflow
+from tensorflow.python.ops.array_ops import zeros
+
+def add(a, b):
+  return a + b
+
+
+c = add(tensorflow.zeros([1, 2]), zeros([2, 2]))

--- a/com.ibm.wala.cast.python.test/data/tf2h2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2h2.py
@@ -1,0 +1,8 @@
+import tensorflow
+from tensorflow.python.framework.sparse_tensor import SparseTensor
+
+def add(a, b):
+  return tensorflow.sparse.add(a,b)
+
+
+c = add(tensorflow.SparseTensor([[0, 0], [1, 2]], [1, 2],[3, 4]), SparseTensor([[0, 0], [1, 2]], [1, 2], [3, 4]))

--- a/com.ibm.wala.cast.python.test/data/tf2i2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2i2.py
@@ -1,0 +1,8 @@
+import tensorflow
+from tensorflow.python.ops.array_ops import fill
+
+def add(a, b):
+  return a + b
+
+
+c = add(tensorflow.fill([1, 2], 2), fill([2, 2], 1))

--- a/com.ibm.wala.cast.python.test/data/tf2j2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2j2.py
@@ -1,0 +1,8 @@
+import tensorflow
+from tensorflow.python.ops.array_ops import zeros_like
+
+def add(a, b):
+  return a + b
+
+
+c = add(tensorflow.zeros_like([1, 2]), zeros_like([2, 2]))

--- a/com.ibm.wala.cast.python.test/data/tf2k2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2k2.py
@@ -1,0 +1,8 @@
+import tensorflow
+from tensorflow.python.ops.array_ops import one_hot
+
+def add(a, b):
+  return a + b
+
+
+c = add(tensorflow.one_hot([0, 1, 2], 3), one_hot([2,4,3], 3))

--- a/com.ibm.wala.cast.python.test/data/tf2l2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2l2.py
@@ -1,0 +1,8 @@
+import tensorflow
+from tensorflow.python.framework.ops import convert_to_tensor
+
+def add(a, b):
+  return a + b
+
+
+c = add(tensorflow.convert_to_tensor(1), convert_to_tensor(2))

--- a/com.ibm.wala.cast.python.test/data/tf2m2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2m2.py
@@ -1,0 +1,8 @@
+import tensorflow
+from tensorflow.python.ops.math_ops import range
+
+def add(a, b):
+  return a + b
+
+
+c = add(tensorflow.range(3, 18, 3), range(5))

--- a/com.ibm.wala.cast.python.test/data/tf2n2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2n2.py
@@ -1,0 +1,15 @@
+import tensorflow
+from tensorflow import Tensor
+
+def func2(t):
+  pass
+
+@tensorflow.function
+def func():
+  a = tensorflow.constant([[1.0, 2.0], [3.0, 4.0]])
+  b = tensorflow.constant([[1.0, 1.0], [0.0, 1.0]])
+  c = tensorflow.matmul(a, b)
+  tensor = Tensor(c.op, 0, tensorflow.float32)
+  func2(tensor)
+
+func()

--- a/com.ibm.wala.cast.python.test/data/tf2n3.py
+++ b/com.ibm.wala.cast.python.test/data/tf2n3.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+from tensorflow.python.framework.ops import Tensor
+
+def func2(t):
+  pass
+
+@tf.function
+def func():
+  a = tf.constant([[1.0, 2.0], [3.0, 4.0]])
+  b = tf.constant([[1.0, 1.0], [0.0, 1.0]])
+  c = tf.matmul(a, b)
+  tensor = Tensor(c.op, 0, tf.float32)
+  func2(tensor)
+
+func()

--- a/com.ibm.wala.cast.python.test/data/tf2o2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2o2.py
@@ -1,0 +1,8 @@
+import tensorflow
+from tensorflow.python.ops.linalg_ops import eye
+
+def add(a, b):
+  return tensorflow.add(a,b)
+
+
+c = add(tensorflow.eye(2,3), eye(2,3))

--- a/com.ibm.wala.cast.python.test/data/tf2p2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2p2.py
@@ -1,0 +1,14 @@
+import tensorflow
+from tensorflow.python.framework.ops import Tensor
+
+def value_index(a,b):
+  return a.value_index + b.value_index
+
+# From https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/Graph#using_graphs_directly_deprecated
+g = tensorflow.Graph()
+with g.as_default():
+  # Defines operation and tensor in graph
+  c = tensorflow.constant(30.0)
+  assert c.graph is g
+
+result = value_index(Tensor(g.get_operations()[0], 0, tensorflow.float32), Tensor(g.get_operations()[0], 0, tensorflow.float32))

--- a/com.ibm.wala.cast.python.test/data/tf2q.py
+++ b/com.ibm.wala.cast.python.test/data/tf2q.py
@@ -1,0 +1,7 @@
+from tensorflow import SparseTensor
+
+def add(a, b):
+  return a
+
+
+c = add(SparseTensor([[0, 0], [1, 2]], [1, 2],[3, 4]), SparseTensor([[0, 0], [1, 2]], [1, 2], [3, 4]))

--- a/com.ibm.wala.cast.python.test/data/tf2r.py
+++ b/com.ibm.wala.cast.python.test/data/tf2r.py
@@ -1,0 +1,7 @@
+from tensorflow import ones
+
+def add(a, b):
+  return a + b
+
+
+c = add(ones([1, 2]), ones([2, 2]))  #  [[2., 2.], [2., 2.]]

--- a/com.ibm.wala.cast.python.test/data/tf2s.py
+++ b/com.ibm.wala.cast.python.test/data/tf2s.py
@@ -1,0 +1,7 @@
+from tensorflow import *
+
+def add(a, b):
+  return a + b
+
+
+c = add(ones([1, 2]), ones([2, 2]))


### PR DESCRIPTION
All "level 1" APIs and one "level 2" API (`random.uniform`) is now inferred via summaries.

This PR addresses the following issues:

1. https://github.com/wala/ML/issues/60
2. https://github.com/wala/ML/issues/49