### PR TITLE
Adding initial support for decorator `tf.function`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -185,6 +185,16 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     testTf2("tf2oo2.py", "func2", 1, 4, 2);
     testTf2("tf2oo3.py", "func2", 1, 4, 2);
     testTf2("tf2oo4.py", "func2", 1, 4, 2);
+    testTf2("tf2_testing_decorator.py", "returned", 1, 3, 2);
+    testTf2("tf2_testing_decorator2.py", "returned", 1, 3, 2);
+    testTf2("tf2_testing_decorator3.py", "returned", 1, 3, 2);
+    testTf2("tf2_testing_decorator4.py", "returned", 1, 3, 2);
+    testTf2("tf2_testing_decorator5.py", "returned", 1, 3, 2);
+    testTf2("tf2_testing_decorator6.py", "returned", 1, 3, 2);
+    testTf2("tf2_testing_decorator7.py", "returned", 1, 3, 2);
+    testTf2("tf2_testing_decorator8.py", "returned", 1, 3, 2);
+    testTf2("tf2_testing_decorator9.py", "returned", 1, 3, 2);
+    testTf2("tf2_testing_decorator10.py", "returned", 1, 3, 2);
   }
 
   private void testTf2(

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -10,6 +10,9 @@
         <new def="train" class="Lobject" />
         <putfield class="LRoot" field="train" fieldType="LRoot" ref="x" value="train" />
 
+        <new def="function" class="Ltensorflow/class/function" />
+        <putfield class="LRoot" field="function" fieldType="LRoot" ref="x" value="function" />
+
         <new def="AdamOptimizer" class="Ltensorflow/functions/AdamOptimizer" />
         <putfield class="LRoot" field="AdamOptimizer" fieldType="LRoot" ref="train" value="AdamOptimizer" />
 
@@ -279,6 +282,36 @@
         <return value="x" />
       </method>
     </class>
+
+    <package name="tensorflow/class">
+
+      <class name="Function" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self test">
+
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self" />
+
+          <return value="test" />
+        </method>
+      </class>
+
+      <class name="function" allocatable="true">
+        <!-- These parameters are from TensorFlow v.2.9 https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/function -->
+        <method name="do" descriptor="()LRoot;" numArgs="10" paramNames="func input_signature autograph jit_compile reduce_retracing experimental_implements experimental_autograph_options experimental_relax_shapes experimental_compile experimental_follow_type_hints">
+          <new def="params" class="Ltensorflow/class/Function" />
+          <putfield class="LRoot" field="func" fieldType="LRoot" ref="params" value="func" />
+          <putfield class="LRoot" field="input_signature" fieldType="LRoot" ref="params" value="input_signature" />
+          <putfield class="LRoot" field="autograph" fieldType="LRoot" ref="params" value="autograph" />
+          <putfield class="LRoot" field="jit_compile" fieldType="LRoot" ref="params" value="jit_compile" />
+          <putfield class="LRoot" field="reduce_retracing" fieldType="LRoot" ref="params" value="reduce_retracing" />
+          <putfield class="LRoot" field="experimental_implements" fieldType="LRoot" ref="params" value="experimental_implements" />
+          <putfield class="LRoot" field="experimental_autograph_options" fieldType="LRoot" ref="params" value="experimental_autograph_options" />
+          <putfield class="LRoot" field="experimental_relax_shapes" fieldType="LRoot" ref="params" value="experimental_relax_shapes" />
+          <putfield class="LRoot" field="experimental_compile" fieldType="LRoot" ref="params" value="experimental_compile" />
+          <putfield class="LRoot" field="experimental_follow_type_hints" fieldType="LRoot" ref="params" value="experimental_follow_type_hints" />
+          <return value="params" />
+        </method>
+      </class>
+    </package>
 
     <package name="tensorflow/objects">
       <class name="feature" allocatable="true" />

--- a/com.ibm.wala.cast.python.test/data/tf2_testing_decorator.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_testing_decorator.py
@@ -1,0 +1,8 @@
+import tensorflow as tf
+
+@tf.function()
+def returned(a):
+  return a
+
+a = tf.range(5)
+b = returned(a)

--- a/com.ibm.wala.cast.python.test/data/tf2_testing_decorator10.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_testing_decorator10.py
@@ -1,0 +1,8 @@
+import tensorflow as tf
+
+@tf.function(experimental_follow_type_hints=True)
+def returned(a):
+  return a
+
+a = tf.range(5)
+b = returned(a)

--- a/com.ibm.wala.cast.python.test/data/tf2_testing_decorator2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_testing_decorator2.py
@@ -1,0 +1,8 @@
+import tensorflow as tf
+
+@tf.function(reduce_retracing=True)
+def returned(a):
+  return a
+
+a = tf.range(5)
+b = returned(a)

--- a/com.ibm.wala.cast.python.test/data/tf2_testing_decorator3.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_testing_decorator3.py
@@ -1,0 +1,9 @@
+import tensorflow as tf
+
+@tf.function(input_signature=(tf.TensorSpec(shape=[None], dtype=tf.float32),))
+@tf.function(reduce_retracing=True)
+def returned(a):
+  return a
+
+a = tf.constant([1.0, 1.0])
+b = returned(a)

--- a/com.ibm.wala.cast.python.test/data/tf2_testing_decorator4.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_testing_decorator4.py
@@ -1,0 +1,8 @@
+import tensorflow as tf
+
+@tf.function(autograph=False)
+def returned(a):
+  return a
+
+a = tf.range(5)
+b = returned(a)

--- a/com.ibm.wala.cast.python.test/data/tf2_testing_decorator5.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_testing_decorator5.py
@@ -1,0 +1,8 @@
+import tensorflow as tf
+
+@tf.function(jit_compile=True)
+def returned(a):
+  return a
+
+a = tf.range(5)
+b = returned(a)

--- a/com.ibm.wala.cast.python.test/data/tf2_testing_decorator6.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_testing_decorator6.py
@@ -1,0 +1,8 @@
+import tensorflow as tf
+
+@tf.function(experimental_implements="google.matmul_low_rank_matrix")
+def returned(a):
+  return a
+
+a = tf.range(5)
+b = returned(a)

--- a/com.ibm.wala.cast.python.test/data/tf2_testing_decorator7.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_testing_decorator7.py
@@ -1,0 +1,8 @@
+import tensorflow as tf
+
+@tf.function(experimental_autograph_options=tf.autograph.experimental.Feature.EQUALITY_OPERATORS)
+def returned(a):
+  return a
+
+a = tf.range(5)
+b = returned(a)

--- a/com.ibm.wala.cast.python.test/data/tf2_testing_decorator8.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_testing_decorator8.py
@@ -1,0 +1,8 @@
+import tensorflow as tf
+
+@tf.function(experimental_relax_shapes=True)
+def returned(a):
+  return a
+
+a = tf.range(5)
+b = returned(a)

--- a/com.ibm.wala.cast.python.test/data/tf2_testing_decorator9.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_testing_decorator9.py
@@ -1,0 +1,8 @@
+import tensorflow as tf
+
+@tf.function(experimental_compile=True)
+def returned(a):
+  return a
+
+a = tf.range(5)
+b = returned(a)


### PR DESCRIPTION
Currently, we are using jython2 in `com.ibm.wala.cast.python.ml.test`, where we don't encounter decorator problems when running the tests. But when we use jython3, we do encounter problems with decorator `tf.function`. Therefore we are adding initial support for the decorator `tf.function` in `tensorflow.xml`. Initial support for `tf.function` because after this change, in jython3, can now process the decorator that has parenthesis e.g. `tf.function()` or `tf.function(...)`. 

Refer to https://github.com/wala/ML/issues/33 for the issue with inconsistent jython versions.

After this change we see:
Test code with parenthesis: 

```python
import tensorflow as tf

@tf.function()
def returned(a):
  return a

a = tf.range(5)
b = returned(a)
```
The analysis of the test with parenthesis:
```
answer:
[Node: <Code body of function Lscript tf2_testing_decorator.py> Context: CallStringContext: [ com.ibm.wala.FakeRootClass.fakeRootMethod()V@2 ], v251][{[D:Symbolic,n, D:Compound,[D:Constant,28, D:Constant,28]] of pixel}]
[Ret-V:Node: synthetic < PythonLoader, Ltensorflow/functions/range, do()LRoot; > Context: CallStringContext: [ script tf2_testing_decorator.py.do()LRoot;@96 ]][{[D:Symbolic,n, D:Compound,[D:Constant,28, D:Constant,28]] of pixel}]
[Node: synthetic < PythonLoader, Ltensorflow/functions/range, do()LRoot; > Context: CallStringContext: [ script tf2_testing_decorator.py.do()LRoot;@96 ], v6][{[D:Symbolic,n, D:Compound,[D:Constant,28, D:Constant,28]] of pixel}]
[Node: <Code body of function Lscript tf2_testing_decorator.py/returned> Context: CallStringContext: [ script tf2_testing_decorator.py.do()LRoot;@98 ], v2][{[D:Symbolic,n, D:Compound,[D:Constant,28, D:Constant,28]] of pixel}]
[Node: <Code body of function Lscript tf2_testing_decorator.py> Context: CallStringContext: [ com.ibm.wala.FakeRootClass.fakeRootMethod()V@2 ], v257][{[D:Symbolic,n, D:Compound,[D:Constant,28, D:Constant,28]] of pixel}]
[Ret-V:Node: <Code body of function Lscript tf2_testing_decorator.py/returned> Context: CallStringContext: [ script tf2_testing_decorator.py.do()LRoot;@98 ]][{[D:Symbolic,n, D:Compound,[D:Constant,28, D:Constant,28]] of pixel}]
```

Test code with parenthesis: 

```python
import tensorflow as tf

@tf.function
def returned(a):
  return a

a = tf.range(5)
b = returned(a)
```

The analysis of the test without parenthesis:
```
answer:
[Node: <Code body of function Lscript tf2_testing_decorator.py> Context: CallStringContext: [ com.ibm.wala.FakeRootClass.fakeRootMethod()V@2 ], v249][{[D:Symbolic,n, D:Compound,[D:Constant,28, D:Constant,28]] of pixel}]
[Ret-V:Node: synthetic < PythonLoader, Ltensorflow/functions/range, do()LRoot; > Context: CallStringContext: [ script tf2_testing_decorator.py.do()LRoot;@95 ]][{[D:Symbolic,n, D:Compound,[D:Constant,28, D:Constant,28]] of pixel}]
[Node: synthetic < PythonLoader, Ltensorflow/functions/range, do()LRoot; > Context: CallStringContext: [ script tf2_testing_decorator.py.do()LRoot;@95 ], v6][{[D:Symbolic,n, D:Compound,[D:Constant,28, D:Constant,28]] of pixel}]
[Node: synthetic < PythonLoader, Ltensorflow/class/Function, do()LRoot; > Context: CallStringContext: [ script tf2_testing_decorator.py.do()LRoot;@97 ], v2][{[D:Symbolic,n, D:Compound,[D:Constant,28, D:Constant,28]] of pixel}]
[Node: <Code body of function Lscript tf2_testing_decorator.py> Context: CallStringContext: [ com.ibm.wala.FakeRootClass.fakeRootMethod()V@2 ], v255][{[D:Symbolic,n, D:Compound,[D:Constant,28, D:Constant,28]] of pixel}]
[Ret-V:Node: synthetic < PythonLoader, Ltensorflow/class/Function, do()LRoot; > Context: CallStringContext: [ script tf2_testing_decorator.py.do()LRoot;@97 ]][{[D:Symbolic,n, D:Compound,[D:Constant,28, D:Constant,28]] of pixel}]
```

We see that with the decorator, `expr` is classified as a `CALL`, and without it is classified as an `Attribute`.