### PR TITLE
Remove typo in XML

### DIFF
--- a/com.ibm.wala.cast.python/data/pytest.xml
+++ b/com.ibm.wala.cast.python/data/pytest.xml
@@ -16,7 +16,7 @@
         <return value="x" />
       </method>
     </class>
-    le
+
     <package name="pytest/class">
 
       <class name="Parametrize" allocatable="true">


### PR DESCRIPTION
Looks like there's a typo here, but unsure if it affects XML processing.