### PR TITLE
Add model call tests

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -201,6 +201,22 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
         0,
         0); // NOTE: Change to testTf2("tf2_test_dataset.py", "add", 2, 3, 2, 3) once
     // https://github.com/wala/ML/issues/89 is fixed.
+    testTf2(
+        "tf2_test_model_call.py",
+        "SequentialModel.__call__",
+        0,
+        2); // NOTE: Change to testTf2("tf2_test_model_call.py", "SequentialModel.__call__", 1, 4,
+    // 2) once
+    // https://github.com/wala/ML/issues/24 is fixed.
+    testTf2(
+        "tf2_test_model_call2.py",
+        "SequentialModel.call",
+        0,
+        2); // NOTE: Change to testTf2("tf2_test_model_call2.py", "SequentialModel.call", 1, 4, 2)
+    // once
+    // https://github.com/wala/ML/issues/24 is fixed.
+    testTf2("tf2_test_model_call3.py", "SequentialModel.call", 1, 4, 2);
+    testTf2("tf2_test_model_call4.py", "SequentialModel.__call__", 1, 4, 2);
   }
 
   private void testTf2(

--- a/com.ibm.wala.cast.python.test/data/tf2_test_model_call.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_model_call.py
@@ -1,0 +1,34 @@
+import tensorflow as tf
+
+
+# Create an override model to classify pictures
+class SequentialModel(tf.keras.Model):
+
+  def __init__(self, **kwargs):
+    super(SequentialModel, self).__init__(**kwargs)
+
+    self.flatten = tf.keras.layers.Flatten(input_shape=(28, 28))
+
+    # Add a lot of small layers
+    num_layers = 100
+    self.my_layers = [tf.keras.layers.Dense(64, activation="relu")
+                      for n in range(num_layers)]
+
+    self.dropout = tf.keras.layers.Dropout(0.2)
+    self.dense_2 = tf.keras.layers.Dense(10)
+
+  def __call__(self, x):
+    x = self.flatten(x)
+
+    for layer in self.my_layers:
+      x = layer(x)
+
+    x = self.dropout(x)
+    x = self.dense_2(x)
+
+    return x
+
+input_data = tf.random.uniform([20, 28, 28])
+
+model = SequentialModel()
+result = model(input_data)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_model_call2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_model_call2.py
@@ -1,0 +1,36 @@
+import tensorflow as tf
+
+# Create an override model to classify pictures
+
+
+class SequentialModel(tf.keras.Model):
+
+  def __init__(self, **kwargs):
+    super(SequentialModel, self).__init__(**kwargs)
+
+    self.flatten = tf.keras.layers.Flatten(input_shape=(28, 28))
+
+    # Add a lot of small layers
+    num_layers = 100
+    self.my_layers = [tf.keras.layers.Dense(64, activation="relu")
+                      for n in range(num_layers)]
+
+    self.dropout = tf.keras.layers.Dropout(0.2)
+    self.dense_2 = tf.keras.layers.Dense(10)
+
+  def call(self, x):
+    x = self.flatten(x)
+
+    for layer in self.my_layers:
+      x = layer(x)
+
+    x = self.dropout(x)
+    x = self.dense_2(x)
+
+    return x
+
+
+input_data = tf.random.uniform([20, 28, 28])
+
+model = SequentialModel()
+result = model(input_data)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_model_call3.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_model_call3.py
@@ -1,0 +1,36 @@
+import tensorflow as tf
+
+# Create an override model to classify pictures
+
+
+class SequentialModel(tf.keras.Model):
+
+  def __init__(self, **kwargs):
+    super(SequentialModel, self).__init__(**kwargs)
+
+    self.flatten = tf.keras.layers.Flatten(input_shape=(28, 28))
+
+    # Add a lot of small layers
+    num_layers = 100
+    self.my_layers = [tf.keras.layers.Dense(64, activation="relu")
+                      for n in range(num_layers)]
+
+    self.dropout = tf.keras.layers.Dropout(0.2)
+    self.dense_2 = tf.keras.layers.Dense(10)
+
+  def call(self, x):
+    x = self.flatten(x)
+
+    for layer in self.my_layers:
+      x = layer(x)
+
+    x = self.dropout(x)
+    x = self.dense_2(x)
+
+    return x
+
+
+input_data = tf.random.uniform([20, 28, 28])
+
+model = SequentialModel()
+result = model.call(input_data)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_model_call4.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_model_call4.py
@@ -1,0 +1,36 @@
+import tensorflow as tf
+
+# Create an override model to classify pictures
+
+
+class SequentialModel(tf.keras.Model):
+
+  def __init__(self, **kwargs):
+    super(SequentialModel, self).__init__(**kwargs)
+
+    self.flatten = tf.keras.layers.Flatten(input_shape=(28, 28))
+
+    # Add a lot of small layers
+    num_layers = 100
+    self.my_layers = [tf.keras.layers.Dense(64, activation="relu")
+                      for n in range(num_layers)]
+
+    self.dropout = tf.keras.layers.Dropout(0.2)
+    self.dense_2 = tf.keras.layers.Dense(10)
+
+  def __call__(self, x):
+    x = self.flatten(x)
+
+    for layer in self.my_layers:
+      x = layer(x)
+
+    x = self.dropout(x)
+    x = self.dense_2(x)
+
+    return x
+
+
+input_data = tf.random.uniform([20, 28, 28])
+
+model = SequentialModel()
+result = model.__call__(input_data)


### PR DESCRIPTION
Adding tests for testing calling a method. We add four tests that include 

1. Calling model indirectly using `call` and `__call__` (2 tests)
2. Calling a model directly using `call` and `__call__` (2 tests)

Related to https://github.com/wala/ML/issues/24