### PR TITLE
Also ignore PyDev project metadata

### DIFF
--- a/com.ibm.wala.cast.python/.gitignore
+++ b/com.ibm.wala.cast.python/.gitignore
@@ -4,3 +4,4 @@ target/
 dependency-reduced-pom.xml
 /build/
 .classpath
+.pydevproject


### PR DESCRIPTION
Minor modification to `.gitignore`.