### PR TITLE
Log parsing errors instead of failing

### DIFF
--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonAnalysisEngine.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonAnalysisEngine.java
@@ -138,7 +138,7 @@ public abstract class PythonAnalysisEngine<T>
     IClassHierarchy cha = null;
 
     try {
-	  cha = SeqClassHierarchyFactory.make(scope, loader);
+      cha = SeqClassHierarchyFactory.make(scope, loader);
     } catch (ClassHierarchyException e) {
       assert false : e;
       return null;
@@ -147,7 +147,10 @@ public abstract class PythonAnalysisEngine<T>
     try {
       Util.checkForFrontEndErrors(cha);
     } catch (WalaException e) {
-      logger.log(Level.WARNING, e, () -> "Encountered WALA exception, most likely from front-end parsing errors.");
+      logger.log(
+          Level.WARNING,
+          e,
+          () -> "Encountered WALA exception, most likely from front-end parsing errors.");
     }
 
     setClassHierarchy(cha);

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonAnalysisEngine.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonAnalysisEngine.java
@@ -147,7 +147,7 @@ public abstract class PythonAnalysisEngine<T>
     try {
       Util.checkForFrontEndErrors(cha);
     } catch (WalaException e) {
-      logger.log(Level.SEVERE, e, () -> "Encountered WALA exception, most likely from front-end parsing errors.");
+      logger.log(Level.WARNING, e, () -> "Encountered WALA exception, most likely from front-end parsing errors.");
     }
 
     setClassHierarchy(cha);


### PR DESCRIPTION
1. Split the class hierarchy construction front-end parsing error checking into two.
2. Log parsing errors instead of throwing an exception.