### PR TITLE
For classes, add a field to the script object just like functions

### DIFF
--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -613,6 +613,20 @@ public class PythonCAstToIRTranslator extends AstTranslator {
                             .PutInstruction(code.cfg().getCurrentInstruction(), v, val, fr));
               });
     }
+
+    code.cfg()
+        .unknownInstructions(
+            () -> {
+              FieldReference fnField =
+                  FieldReference.findOrCreate(
+                      PythonTypes.Root,
+                      Atom.findOrCreateUnicodeAtom(n.getName()),
+                      PythonTypes.Root);
+              code.cfg()
+                  .addInstruction(
+                      Python.instructionFactory()
+                          .PutInstruction(code.cfg().getCurrentInstruction(), 1, v, fnField));
+            });
   }
 
   @Override


### PR DESCRIPTION
Then, (external) classes can be found by the PA when they are imported. Otherwise, they cannot be found.

We can't a test for this because we found that `com.ibm.wala.cast.python.test` is run twice during the Maven build. And, the behavior of the code differs between the builds. Thus, on one run, the assertions pass, and on the other, the assertions fail. The only difference I can see is that the first test uses Python files from `target/`, while the second passes uses the ones from the repo. Other than that, I have no idea what the difference is and why it's run twice in the first place.

Still, this fix works in our client application. Thus, I feel that the fix would be beneficial for someone as it solves a significant bug in our client.