### PR TITLE
Make test directories a "resource"

### DIFF
--- a/com.ibm.wala.cast.python.jython.test/pom.xml
+++ b/com.ibm.wala.cast.python.jython.test/pom.xml
@@ -49,6 +49,11 @@
     </dependency>
   </dependencies>
   <build>
+    <resources>
+      <resource>
+        <directory>.</directory>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/com.ibm.wala.cast.python.jython3.test/pom.xml
+++ b/com.ibm.wala.cast.python.jython3.test/pom.xml
@@ -57,6 +57,11 @@
     </dependency>
   </dependencies>
   <build>
+    <resources>
+      <resource>
+        <directory>.</directory>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Seems to quell M2E warnings.