### PR TITLE
Build enhancements

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install IDE.
       run: |
         pushd ${{ runner.temp }}/IDE/com.ibm.wala.cast.lsp
-        mvn clean install -B -q -DskipTests
+        mvn install -B -q -DskipTests
         popd
     - name: Install Python.
       uses: actions/setup-python@v5
@@ -47,4 +47,4 @@ jobs:
     - name: Check formatting with spotless.
       run: mvn spotless:check -B
     - name: Build with Maven
-      run: mvn -Dlogging.config.file=\${maven.multiModuleProjectDirectory}/logging.ci.properties clean verify -B
+      run: mvn -Dlogging.config.file=\${maven.multiModuleProjectDirectory}/logging.ci.properties verify -B

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ install:
  - mvn clean install -B -q -DskipTests
  - popd
  - pip install -r requirements.txt
-script:
+before_script:
  - mvn spotless:check -B
+script:
  - mvn -Dlogging.config.file=\${maven.multiModuleProjectDirectory}/logging.ci.properties clean verify -B
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,13 @@ install:
  - popd
  - popd
  - pushd /tmp/IDE/com.ibm.wala.cast.lsp
- - mvn clean install -B -q -DskipTests
+ - mvn install -B -q -DskipTests
  - popd
  - pip install -r requirements.txt
 before_script:
  - mvn spotless:check -B
 script:
- - mvn -Dlogging.config.file=\${maven.multiModuleProjectDirectory}/logging.ci.properties clean verify -B
+ - mvn -Dlogging.config.file=\${maven.multiModuleProjectDirectory}/logging.ci.properties verify -B
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/


### PR DESCRIPTION
- Fail the build earlier.
  - We don't want to run the tests if spotless fails.
- Remove `clean`.
  - Try to use previous results.