### PR TITLE
Move parallel test flag out of config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <wala.version>1.6.0</wala.version>
     <spotless.version>2.43.0</spotless.version>
     <maven.surefire.version>3.0.0-M7</maven.surefire.version>
+    <parallel>both</parallel>
     <logging.config.file>${maven.multiModuleProjectDirectory}/logging.properties</logging.config.file>
     <black.version>24.1.1</black.version>
   </properties>
@@ -133,7 +134,6 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven.surefire.version}</version>
           <configuration>
-            <parallel>both</parallel>
             <threadCount>1</threadCount>
             <systemPropertyVariables>
               <!-- Set JUL Formatting -->


### PR DESCRIPTION
And into properties. This way we can override it on the command-line during debugging.