### PR TITLE
Ensure that the function under test exists

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /** Test TF2 APIs. */
@@ -3808,6 +3809,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
     final String functionSignature =
         "script " + filename.replace('/', '.') + "." + functionName + ".do()LRoot;";
+
+    // check that the function exists in the call graph.
+    assertTrue(
+        "Function must exist in call graph.",
+        CG.stream()
+            .map(CGNode::getMethod)
+            .map(IMethod::getSignature)
+            .anyMatch(s -> s.equals(functionSignature)));
 
     // get the tensor variables for the function.
     Set<TensorVariable> functionTensorVariables =


### PR DESCRIPTION
Ensure that the function under test exists in the call graph. Otherwise, we could test a function that doesn't exist and the test will still pass.