### PR TITLE
Fix bug with dataset iterator processing

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -961,7 +961,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_dataset18.py", "add", 2, 2, 2, 3);
     test("tf2_test_dataset18.py", "f", 1, 1, 2);
-    test("tf2_test_dataset18.py", "g", 0, 2);
+    test("tf2_test_dataset18.py", "g", 0, 1);
   }
 
   /** Test a dataset that uses an iterator. */

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -1107,6 +1107,20 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_dataset33.py", "f", 1, 1, 2);
   }
 
+  /** Test a dataset that uses an iterator. */
+  @Test
+  public void testDataset34()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_dataset34.py", "add", 2, 2, 2, 3);
+  }
+
+  /** Test a dataset that uses an iterator. */
+  @Test
+  public void testDataset35()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_dataset35.py", "add", 2, 2, 2, 3);
+  }
+
   /**
    * Test enumerating a dataset (https://github.com/wala/ML/issues/140). The first element of the
    * tuple returned isn't a tensor.

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -1121,6 +1121,21 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_dataset35.py", "add", 2, 2, 2, 3);
   }
 
+  /** Test a dataset that uses an iterator. */
+  @Test
+  public void testDataset36()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_dataset36.py", "id1", 1, 1, 2);
+    //    test("tf2_test_dataset36.py", "id2", 1, 1, 2);
+  }
+
+  /** Test a dataset that uses an iterator. */
+  @Test
+  public void testDataset37()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_dataset37.py", "add", 2, 2, 2, 3);
+  }
+
   /**
    * Test enumerating a dataset (https://github.com/wala/ML/issues/140). The first element of the
    * tuple returned isn't a tensor.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -132,6 +132,9 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           // We potentially have a function call that generates a tensor.
           SSAAbstractInvokeInstruction ni = (SSAAbstractInvokeInstruction) inst;
 
+          // don't consider exceptions as a data source.
+          if (ni.getException() == vn) continue;
+
           if (ni.getCallSite()
                   .getDeclaredTarget()
                   .getName()

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -155,19 +155,11 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
                 if (reference.equals(NEXT.getDeclaringClass())) {
                   // it's a call to `next()`. Look up the call to `iter()`.
                   int iterator = ni.getUse(1);
-                  SSAInstruction iteratorDef = du.getDef(iterator);
 
-                  // Let's see if the iterator is over a tensor dataset.
-                  if (iteratorDef != null && iteratorDef.getNumberOfUses() > 1) {
-                    // Get the argument.
-                    int iterArg = iteratorDef.getUse(1);
-                    processInstructionInterprocedurally(
-                        iteratorDef, iterArg, localPointerKeyNode, src, sources, pointerAnalysis);
-                  } else
-                    // Use the original instruction. NOTE: We can only do this because `iter()` is
-                    // currently just passing-through its argument.
-                    processInstructionInterprocedurally(
-                        ni, iterator, localPointerKeyNode, src, sources, pointerAnalysis);
+                  // Use the original instruction. NOTE: We can only do this because `iter()` is
+                  // currently just passing-through its argument.
+                  processInstructionInterprocedurally(
+                      ni, iterator, localPointerKeyNode, src, sources, pointerAnalysis);
                 }
               }
             }

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dataset34.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dataset34.py
@@ -1,0 +1,24 @@
+import tensorflow as tf
+
+
+class C:
+
+    def __init__(self, some_iter):
+        self.some_iter = some_iter
+
+    def __str__(self):
+        return str(self.some_iter)
+
+
+def add(a, b):
+    return a + b
+
+
+dataset = tf.data.Dataset.from_tensor_slices([1, 2, 3])
+my_iter = iter(dataset)
+c = C(my_iter)
+length = len(dataset)
+
+for _ in range(length):
+    element = next(c.some_iter)
+    add(element, element)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dataset35.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dataset35.py
@@ -1,0 +1,19 @@
+import tensorflow as tf
+
+
+def add(a, b):
+    return a + b
+
+
+def gen_iter(ds):
+    return iter(ds)
+
+
+dataset = tf.data.Dataset.from_tensor_slices([1, 2, 3])
+
+my_iter = gen_iter(dataset)
+length = len(dataset)
+
+for _ in range(length):
+    element = next(my_iter)
+    add(element, element)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dataset36.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dataset36.py
@@ -1,0 +1,34 @@
+import tensorflow as tf
+
+
+class C:
+
+    def __init__(self, some_iter):
+        self.some_iter = some_iter
+
+    def __str__(self):
+        return str(self.some_iter)
+
+
+def id1(a):
+    return a
+
+
+def id2(a):
+    return a
+
+
+def gen():
+    yield "42", tf.constant("43")
+
+
+dataset = tf.data.Dataset.from_generator(gen, output_types=(tf.string, tf.string))
+
+my_iter = iter(dataset)
+c = C(my_iter)
+length = 1
+
+for _ in range(length):
+    x, y = next(c.some_iter)
+    id1(x)
+    id2(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dataset37.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dataset37.py
@@ -1,0 +1,28 @@
+import tensorflow as tf
+
+
+class C:
+
+    def __init__(self, some_iter):
+        self.some_iter = some_iter
+
+    def __str__(self):
+        return str(self.some_iter)
+
+
+def add(a, b):
+    return a + b
+
+
+def gen_iter(dataset):
+    my_iter = iter(dataset)
+    return C(my_iter)
+
+
+dataset = tf.data.Dataset.from_tensor_slices([1, 2, 3])
+c = gen_iter(dataset)
+length = len(dataset)
+
+for _ in range(length):
+    element = next(c.some_iter)
+    add(element, element)


### PR DESCRIPTION
- Fix bug with iterating over datasets whose elements may be tuples.
  - This happens when a tensor dataset generator outputs tensors in a specific format.
  - Previously, Ariadne was not inferring tensors that were being picked out of the tuple during dataset iteration.
  - Added corresponding tests.
- Don't consider exceptions as tensor dataflow sources.
  - This was happening in the old code. I've added it to the new code as well.
- Since invocation instructions are processed in multiple places, I've extracted a common method.
  - The two different call sites differ on the `src` points-to variable to be added.
  - This guarantees that the order in which the points-to variables are processed doesn't matter.
