### PR TITLE
Continue module parsing despite Jython parsing errors

### DIFF
--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -14,6 +14,7 @@ import static com.ibm.wala.cast.python.util.Util.CLASS_METHOD_ANNOTATION_NAME;
 import static com.ibm.wala.cast.python.util.Util.DYNAMIC_ANNOTATION_KEY;
 import static com.ibm.wala.cast.python.util.Util.STATIC_METHOD_ANNOTATION_NAME;
 import static com.ibm.wala.cast.python.util.Util.getNameStream;
+import static java.util.logging.Logger.getLogger;
 
 import com.ibm.wala.cast.ir.translator.AbstractClassEntity;
 import com.ibm.wala.cast.ir.translator.AbstractCodeEntity;

--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -60,6 +60,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.logging.Logger;
 import org.python.antlr.PythonTree;
 import org.python.antlr.ast.Assert;
 import org.python.antlr.ast.Assign;
@@ -141,6 +142,8 @@ import org.python.core.PyObject;
 
 public abstract class PythonParser<T> extends AbstractParser<T> implements TranslatorToCAst {
 
+  private static final Logger LOGGER = getLogger(PythonParser.class.getName());
+  
   private static boolean COMPREHENSION_IR = true;
 
   private CAstType codeBody =

--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -2376,7 +2376,9 @@ public abstract class PythonParser<T> extends AbstractParser<T> implements Trans
                       }
                     });
               });
-      throw new TranslatorToCAst.Error(warnings);
+
+      // Log the parsing errors (best-effort).
+      warnings.forEach(w -> LOGGER.warning(() -> "Encountered parsing problem: " + w));
     }
 
     try {

--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -143,7 +143,7 @@ import org.python.core.PyObject;
 public abstract class PythonParser<T> extends AbstractParser<T> implements TranslatorToCAst {
 
   private static final Logger LOGGER = getLogger(PythonParser.class.getName());
-  
+
   private static boolean COMPREHENSION_IR = true;
 
   private CAstType codeBody =


### PR DESCRIPTION
Let's see if we can still go through (similar to [b3c28a86a282f22f45b8e1203ef8eec8dc91214a](https://github.com/wala/ML/pull/125)).

## Differences
1. Log a warning instead of throwing an exception, which stops the module from processing. We are already doing this further up the stack anyway: https://github.com/wala/ML/blob/ef1cca799d7726bfc70cec7b838ebeec2516d5e4/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonAnalysisEngine.java#L159-L166
2. Continue to convert to CAst despite the parsing error coming out of Jython. This is a workaround for https://github.com/wala/ML/issues/205. I think this should be OK (best-effort) as I don't see it contributing to any soundness issues. And, from what I am seeing in the [logs](https://github.com/ponder-lab/ML/actions/runs/9897547494/job/27342295209#step:12:32780), the parsing errors are "mild."