### PR TITLE
Remove redundant `mvn verify`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ install:
  - mvn install -B -q -DskipTests
  - popd
 script:
- - mvn -Dlogging.config.file=\${maven.multiModuleProjectDirectory}/logging.ci.properties verify -B
  - mvn -Dlogging.config.file=\${maven.multiModuleProjectDirectory}/logging.ci.properties verify -Pjacoco -B
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
Extra `mvn verify` in the Travis CI build. We don't use this build, but it was there historically, and we've been trying to keep it in sync in case it is used again (not a big effort).