### PR TITLE
Add missing aggregate coverage reporting modules

### DIFF
--- a/com.ibm.wala.cast.python.report/pom.xml
+++ b/com.ibm.wala.cast.python.report/pom.xml
@@ -22,6 +22,26 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>com.ibm.wala.cast.python.jython</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>com.ibm.wala.cast.python.jython.test</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>com.ibm.wala.cast.python.jython3</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>com.ibm.wala.cast.python.jython3.test</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>com.ibm.wala.cast.python.ml</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
They were probably not working at some point, but they're working now.
