### PR TITLE
Remove use of `maven.multiModuleProjectDirectory` property

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -49,7 +49,7 @@ jobs:
         mvn install -B -q -DskipTests
         popd
     - name: Build with Maven
-      run: mvn -Dlogging.config.file=\${maven.multiModuleProjectDirectory}/logging.ci.properties verify -B -Pjacoco
+      run: mvn -Dlogging.config.file=./logging.ci.properties verify -B -Pjacoco
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5
       with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
  - mvn install -B -q -DskipTests
  - popd
 script:
- - mvn -Dlogging.config.file=\${maven.multiModuleProjectDirectory}/logging.ci.properties verify -Pjacoco -B
+ - mvn -Dlogging.config.file=./logging.ci.properties verify -Pjacoco -B
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/com.ibm.wala.cast.python.jython.test/logging.properties
+++ b/com.ibm.wala.cast.python.jython.test/logging.properties
@@ -1,0 +1,1 @@
+../logging.properties

--- a/com.ibm.wala.cast.python.jython3.test/logging.properties
+++ b/com.ibm.wala.cast.python.jython3.test/logging.properties
@@ -1,0 +1,1 @@
+../logging.properties

--- a/com.ibm.wala.cast.python.ml.test/TestTensorflow2Model.launch
+++ b/com.ibm.wala.cast.python.ml.test/TestTensorflow2Model.launch
@@ -25,5 +25,5 @@
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.ibm.wala.cast.python.ml.test.TestTensorflow2Model"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="com.ibm.wala.cast.python.ml.test"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea&#10; -Dpython.import.site=false&#10;-Djava.util.logging.config.file=${maven.multiModuleProjectDirectory}/logging.properties"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea&#10; -Dpython.import.site=false&#10;-Djava.util.logging.config.file=./logging.properties"/>
 </launchConfiguration>

--- a/com.ibm.wala.cast.python.ml.test/TestTensorflow2Model.testModule.launch
+++ b/com.ibm.wala.cast.python.ml.test/TestTensorflow2Model.testModule.launch
@@ -22,5 +22,5 @@
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.ibm.wala.cast.python.ml.test.TestTensorflow2Model"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="com.ibm.wala.cast.python.ml.test"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea&#10;-Dpython.import.site=false&#10;-Djava.util.logging.config.file=${maven.multiModuleProjectDirectory}/logging.properties"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea&#10; -Dpython.import.site=false&#10;-Djava.util.logging.config.file=./logging.properties"/>
 </launchConfiguration>

--- a/com.ibm.wala.cast.python.ml.test/TestTensorflow2Model.testModule2.launch
+++ b/com.ibm.wala.cast.python.ml.test/TestTensorflow2Model.testModule2.launch
@@ -21,5 +21,5 @@
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.ibm.wala.cast.python.ml.test.TestTensorflow2Model"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="com.ibm.wala.cast.python.ml.test"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea&#10;-Dpython.import.site=false&#10;-Djava.util.logging.config.file=${maven.multiModuleProjectDirectory}/logging.properties"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea&#10; -Dpython.import.site=false&#10;-Djava.util.logging.config.file=./logging.properties"/>
 </launchConfiguration>

--- a/com.ibm.wala.cast.python.ml.test/TestTensorflow2Model.testModule3.launch
+++ b/com.ibm.wala.cast.python.ml.test/TestTensorflow2Model.testModule3.launch
@@ -21,5 +21,5 @@
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.ibm.wala.cast.python.ml.test.TestTensorflow2Model"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="com.ibm.wala.cast.python.ml.test"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea&#10; -Dpython.import.site=false&#10;-Djava.util.logging.config.file=${maven.multiModuleProjectDirectory}/logging.properties"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea&#10; -Dpython.import.site=false&#10;-Djava.util.logging.config.file=./logging.properties"/>
 </launchConfiguration>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <spotless.version>2.44.5</spotless.version>
     <maven.surefire.version>3.5.3</maven.surefire.version>
     <parallel>both</parallel>
-    <logging.config.file>${maven.multiModuleProjectDirectory}/logging.properties</logging.config.file>
+    <logging.config.file>./logging.properties</logging.config.file>
     <jacoco-version>0.8.13</jacoco-version>
     <argLine/>
   </properties>
@@ -226,7 +226,7 @@
                 <eclipseWtp>
                   <type>XML</type>
                   <files>
-                    <file>${maven.multiModuleProjectDirectory}/spotless.xml.prefs</file>
+                    <file>./spotless.xml.prefs</file>
                   </files>
                 </eclipseWtp>
                 <trimTrailingWhitespace/>


### PR DESCRIPTION
Looks like it's unsupported for external use. See https://github.com/apache/iotdb/issues/12981.