### PR TITLE
Sort test methods

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -50,662 +50,6 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final Logger LOGGER = Logger.getLogger(TestTensorflow2Model.class.getName());
 
   @Test
-  public void testAdd7()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add7.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd8()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add8.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd9()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add9.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd10()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add10.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd11()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add11.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd12()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add12.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd13()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add13.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd14()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add14.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd15()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add15.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd16()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add16.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd17()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add17.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd18()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add18.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd19()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add19.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd20()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add20.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd21()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add21.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd22()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add22.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd23()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add23.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd24()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add24.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd25()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add25.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd26()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add26.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd27()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add27.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd28()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add28.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd29()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add29.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd30()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add30.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd31()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add31.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd32()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add32.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd33()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add33.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd34()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add34.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd35()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add35.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd36()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add36.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd37()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add37.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd38()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add38.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd39()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add39.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd40()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add40.py", "func2", 1, 1, 2);
-  }
-
-  @Test
-  public void testAdd41()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add41.py", "func2", 1, 1, 2);
-  }
-
-  @Test
-  public void testAdd42()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add42.py", "func2", 1, 1, 2);
-  }
-
-  @Test
-  public void testAdd43()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add43.py", "add", 2, 3, 2, 3);
-  }
-
-  @Test
-  public void testAdd44()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add44.py", "add", 2, 3, 2, 3);
-  }
-
-  @Test
-  public void testAdd45()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add45.py", "value_index", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd46()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add46.py", "value_index", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd47()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add47.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd48()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add48.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd49()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    // NOTE: Set the expected number of tensor variables to 3 once
-    // https://github.com/wala/ML/issues/135 is fixed.
-    test("tf2_test_add49.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd50()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add50.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd51()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add51.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd52()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add52.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd53()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add53.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd54()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add54.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd55()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add55.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd56()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add56.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd57()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add57.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd58()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add58.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd59()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add59.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd60()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add60.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd61()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add61.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd62()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add62.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd63()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add63.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd64()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add64.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd65()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add65.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd66()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add66.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd67()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add67.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd68()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add68.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd69()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add69.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd70()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add70.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd71()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add71.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd72()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add72.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd73()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add73.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd74()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add74.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd75()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add75.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd76()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add76.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd77()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add77.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd78()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add78.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd79()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add79.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd80()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add80.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd81()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add81.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd82()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add82.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd83()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add83.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd84()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add84.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd85()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add85.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd86()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add86.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd87()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add87.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd88()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add88.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd89()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add89.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd90()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add90.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd91()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add91.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd92()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add92.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd93()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add93.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd94()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add94.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd95()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add95.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd96()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add96.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd97()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add97.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd98()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add98.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd99()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add99.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd100()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add100.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd101()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add101.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd102()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add102.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd103()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add103.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd104()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add104.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd105()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add105.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd106()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add106.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd107()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add107.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd108()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add108.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd109()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add109.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd110()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add110.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd111()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add111.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd112()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add112.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd113()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add113.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd114()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add114.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
-  public void testAdd115()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_add115.py", "add", 2, 2, 2, 3);
-  }
-
-  @Test
   public void testValueIndex()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_value_index.py", "value_index", 2, 2, 2, 3);
@@ -1391,6 +735,662 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testAdd6()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_add6.py", "f", 1, 1, 2);
+  }
+
+  @Test
+  public void testAdd7()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add7.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd8()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add8.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd9()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add9.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd10()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add10.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd11()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add11.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd12()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add12.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd13()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add13.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd14()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add14.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd15()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add15.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd16()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add16.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd17()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add17.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd18()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add18.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd19()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add19.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd20()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add20.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd21()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add21.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd22()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add22.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd23()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add23.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd24()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add24.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd25()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add25.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd26()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add26.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd27()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add27.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd28()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add28.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd29()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add29.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd30()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add30.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd31()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add31.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd32()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add32.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd33()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add33.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd34()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add34.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd35()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add35.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd36()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add36.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd37()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add37.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd38()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add38.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd39()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add39.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd40()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add40.py", "func2", 1, 1, 2);
+  }
+
+  @Test
+  public void testAdd41()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add41.py", "func2", 1, 1, 2);
+  }
+
+  @Test
+  public void testAdd42()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add42.py", "func2", 1, 1, 2);
+  }
+
+  @Test
+  public void testAdd43()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add43.py", "add", 2, 3, 2, 3);
+  }
+
+  @Test
+  public void testAdd44()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add44.py", "add", 2, 3, 2, 3);
+  }
+
+  @Test
+  public void testAdd45()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add45.py", "value_index", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd46()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add46.py", "value_index", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd47()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add47.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd48()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add48.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd49()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    // NOTE: Set the expected number of tensor variables to 3 once
+    // https://github.com/wala/ML/issues/135 is fixed.
+    test("tf2_test_add49.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd50()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add50.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd51()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add51.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd52()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add52.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd53()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add53.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd54()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add54.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd55()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add55.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd56()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add56.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd57()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add57.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd58()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add58.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd59()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add59.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd60()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add60.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd61()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add61.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd62()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add62.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd63()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add63.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd64()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add64.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd65()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add65.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd66()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add66.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd67()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add67.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd68()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add68.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd69()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add69.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd70()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add70.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd71()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add71.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd72()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add72.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd73()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add73.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd74()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add74.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd75()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add75.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd76()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add76.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd77()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add77.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd78()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add78.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd79()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add79.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd80()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add80.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd81()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add81.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd82()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add82.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd83()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add83.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd84()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add84.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd85()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add85.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd86()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add86.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd87()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add87.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd88()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add88.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd89()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add89.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd90()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add90.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd91()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add91.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd92()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add92.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd93()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add93.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd94()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add94.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd95()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add95.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd96()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add96.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd97()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add97.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd98()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add98.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd99()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add99.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd100()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add100.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd101()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add101.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd102()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add102.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd103()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add103.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd104()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add104.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd105()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add105.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd106()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add106.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd107()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add107.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd108()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add108.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd109()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add109.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd110()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add110.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd111()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add111.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd112()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add112.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd113()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add113.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd114()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add114.py", "add", 2, 2, 2, 3);
+  }
+
+  @Test
+  public void testAdd115()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_add115.py", "add", 2, 2, 2, 3);
   }
 
   @Test


### PR DESCRIPTION
Following 00020106a0d5600dbd8146803bc54c387588b0ef, we now have a situation where the test methods appear out-of-order due to the method renaming. This PR puts them back in order.

I have a more significant PR lined up, but it wouldn't make sense to issue that one without this one first.