### PR TITLE
Point the WALA submodule to its latest commit on its mainline branch

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,12 +15,6 @@ jobs:
       uses: actions/checkout@v5
       with:
         submodules: 'recursive'
-    - name: Pull the latest changes from the `jumpstart-jep-merge` branch of WALA.
-      run: |
-        pushd WALA
-        git fetch origin
-        git checkout jumpstart-jep-merge # Should be at the HEAD of the branch.
-        popd
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,7 +18,8 @@ jobs:
     - name: Pull the latest changes from the `jumpstart-jep-merge` branch of WALA.
       run: |
         pushd WALA
-        git pull origin jumpstart-jep-merge
+        git fetch origin
+        git checkout jumpstart-jep-merge # Should be at the HEAD of the branch.
         popd
     - name: Set up JDK 21
       uses: actions/setup-java@v4

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,7 +17,9 @@ jobs:
         submodules: 'recursive'
     - name: Update the WALA Git submodule
       run: |
-        git submodule foreach --recursive 'git fetch'
+        cd WALA
+        git fetch origin
+        cd -
         git submodule update --init --recursive --remote -- WALA
     - name: Set up JDK 21
       uses: actions/setup-java@v4

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,7 +41,7 @@ jobs:
         popd
         popd
       shell: bash
-    - name: Install WALA `jumpstart-jep-merge` branch.
+    - name: Install WALA.
       run: |
         pushd WALA
         ./gradlew build publishToMavenLocal -x test -x javadoc -x lintMarkdown

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,9 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Update the WALA Git submodule
-      run: git submodule update --init --recursive --remote -- WALA
+      run: |
+        git submodule sync --recursive
+        git submodule update --init --recursive --remote -- WALA
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Update the WALA Git submodule
-      run: git submodule update --recursive --remote -- WALA
+      run: git submodule update --init --recursive --remote -- WALA
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,9 +18,9 @@ jobs:
     - name: Update the WALA Git submodule
       run: |
         cd WALA
-        git fetch origin
+        git remote set-branches origin jumpstart-jep-merge
         cd -
-        git submodule update --init --recursive --remote -- WALA
+        git submodule update --recursive --remote -- WALA
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,12 +15,12 @@ jobs:
       uses: actions/checkout@v5
       with:
         submodules: 'recursive'
-    - name: Update the WALA Git submodule
-      run: |
-        cd WALA
-        git remote set-branches origin jumpstart-jep-merge
-        cd -
-        git submodule update --recursive --remote -- WALA
+    - name: Check out wala/WALA `jumpstart-jep-merge` sources
+      uses: actions/checkout@v5
+      with:
+        repository: 'https://github.com/wala/WALA'
+        ref: 'jumpstart-jep-merge'
+        path: 'WALA'
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Check out wala/WALA `jumpstart-jep-merge` sources
       uses: actions/checkout@v5
       with:
-        repository: 'https://github.com/wala/WALA'
+        repository: 'wala/WALA'
         ref: 'jumpstart-jep-merge'
         path: 'WALA'
     - name: Set up JDK 21

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Update the WALA Git submodule
-      run: git submodule update --init --recursive --remote -- WALA
+      run: git submodule update --init --recursive --remote
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,6 +15,10 @@ jobs:
       uses: actions/checkout@v5
       with:
         submodules: 'recursive'
+    - name: Update the WALA Git submodule
+      run: |
+        git pull --recurse-submodules
+        git submodule update --remote --recursive -- WALA
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,7 +17,7 @@ jobs:
         submodules: 'recursive'
     - name: Update the WALA Git submodule
       run: |
-        git submodule sync --recursive
+        git submodule foreach --recursive 'git fetch'
         git submodule update --init --recursive --remote -- WALA
     - name: Set up JDK 21
       uses: actions/setup-java@v4

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,6 +15,8 @@ jobs:
       uses: actions/checkout@v5
       with:
         submodules: 'recursive'
+    - name: Update the WALA submodule with its latest commit
+      run: git submodule update --recursive --remote
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,9 +16,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Update the WALA Git submodule
-      run: |
-        git pull --recurse-submodules
-        git submodule update --remote --recursive -- WALA
+      run: git submodule update --init --recursive --remote -- WALA
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Update the WALA Git submodule
-      run: git submodule update --init --recursive --remote
+      run: git submodule update --recursive --remote -- WALA
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,12 +15,6 @@ jobs:
       uses: actions/checkout@v5
       with:
         submodules: 'recursive'
-    - name: Check out wala/WALA `jumpstart-jep-merge` sources
-      uses: actions/checkout@v5
-      with:
-        repository: 'wala/WALA'
-        ref: 'jumpstart-jep-merge'
-        path: 'WALA'
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,3 @@
 [submodule "WALA"]
 	path = WALA
 	url = https://github.com/wala/WALA
-	branch = jumpstart-jep-merge

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 [submodule "WALA"]
 	path = WALA
 	url = https://github.com/wala/WALA
-	branch = jumpstart-jep-merge
+	branch = origin/jumpstart-jep-merge

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "IDE"]
 	path = IDE
 	url = https://github.com/wala/IDE
+	branch = master
 [submodule "jython3"]
 	path = jython3
 	url = https://github.com/ponder-lab/jython3.git
+	branch = master
 [submodule "WALA"]
 	path = WALA
 	url = https://github.com/wala/WALA

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "IDE"]
 	path = IDE
 	url = https://github.com/wala/IDE
-	branch = master
 [submodule "jython3"]
 	path = jython3
 	url = https://github.com/ponder-lab/jython3.git
-	branch = master
 [submodule "WALA"]
 	path = WALA
 	url = https://github.com/wala/WALA

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 [submodule "WALA"]
 	path = WALA
 	url = https://github.com/wala/WALA
-	branch = origin/jumpstart-jep-merge
+	branch = jumpstart-jep-merge


### PR DESCRIPTION
This pull request updates how the WALA submodule is managed in the CI workflow. The main change is that the workflow now always fetches the latest commit from WALA's default branch, rather than a specific branch, and removes explicit references to the `jumpstart-jep-merge` branch.

WALA submodule management updates:

* The `.github/workflows/continuous-integration.yml` workflow now runs `git submodule update --recursive --remote` to ensure the WALA submodule is always updated to its latest commit.
* The `.gitmodules` file no longer pins the WALA submodule to the `jumpstart-jep-merge` branch, so it will follow the default branch instead.
* The workflow step previously labeled "Install WALA `jumpstart-jep-merge` branch" is now simply "Install WALA," reflecting the branch-agnostic setup.