### PR TITLE
Use `${maven.multiModuleProjectDirectory}/spotless.xml.prefs` for robust resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
                 <eclipseWtp>
                   <type>XML</type>
                   <files>
-                    <file>./spotless.xml.prefs</file>
+                    <file>${maven.multiModuleProjectDirectory}/spotless.xml.prefs</file>
                   </files>
                 </eclipseWtp>
                 <trimTrailingWhitespace/>


### PR DESCRIPTION
## Problem

`pom.xml` line 233 references the Spotless prefs file with a relative path:

```xml
<eclipseWtp>
  <type>XML</type>
  <files>
    <file>./spotless.xml.prefs</file>
  </files>
</eclipseWtp>
```

Relative paths resolve against Maven's current working directory at invocation time. When Maven is run from the multi-module root (the typical case), this works. But it can fail when invoked from elsewhere — a submodule's `basedir`, an IDE's per-module test run, or a nested Maven invocation — because the file isn't at `./spotless.xml.prefs` from those contexts.

## Fix

Use `${maven.multiModuleProjectDirectory}`, which always points at the directory containing the topmost parent POM regardless of how Maven is invoked:

```xml
<file>${maven.multiModuleProjectDirectory}/spotless.xml.prefs</file>
```

## Verification

```
$ mvn spotless:check                                        # from root: BUILD SUCCESS
$ mvn -pl ml/com.ibm.wala.cast.python.ml spotless:check     # submodule-targeted: BUILD SUCCESS
```

Both pass after the change. The submodule-targeted invocation is the case where the relative path was fragile.
