### PR TITLE
Recover from Jython interpreter init failure during constant folding

### DIFF
--- a/jython/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/loader/Python3Loader.java
+++ b/jython/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/loader/Python3Loader.java
@@ -103,18 +103,20 @@ public class Python3Loader extends PythonLoader {
               @Override
               protected Object eval(CAstOperator op, Object lhs, Object rhs) {
                 String s = lhs + " " + op.getValue() + " " + rhs;
+
+                PythonInterpreter ip = Python3Interpreter.getInterp();
+                if (ip == null) {
+                  // Jython init failed (memoized in Python3Interpreter). Skip constant folding
+                  // for this expression; analysis remains correct, just less precise. Don't log
+                  // an "Evaluating:" entry — nothing is actually evaluated, and the underlying
+                  // init failure was already announced from getInterp().
+                  return null;
+                }
                 logger.info(() -> "Evaluating: " + s);
 
                 // Use the Python interpreter to evaluate the expression.
                 PyUnicode unicode = new PyUnicode(s);
                 PyObject x;
-
-                PythonInterpreter ip = Python3Interpreter.getInterp();
-                if (ip == null) {
-                  // Jython init failed (memoized in Python3Interpreter). Skip constant folding
-                  // for this expression; analysis remains correct, just less precise.
-                  return null;
-                }
 
                 try {
                   x = ip.eval(unicode);

--- a/jython/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/loader/Python3Loader.java
+++ b/jython/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/loader/Python3Loader.java
@@ -108,8 +108,15 @@ public class Python3Loader extends PythonLoader {
                 PyUnicode unicode = new PyUnicode(s);
                 PyObject x;
 
+                org.python.util.PythonInterpreter ip = Python3Interpreter.getInterp();
+                if (ip == null) {
+                  // Jython init failed (memoized in Python3Interpreter). Skip constant folding
+                  // for this expression; analysis remains correct, just less precise.
+                  return null;
+                }
+
                 try {
-                  x = Python3Interpreter.getInterp().eval(unicode);
+                  x = ip.eval(unicode);
                 } catch (PySyntaxError e) {
                   // Handle syntax errors gracefully.
                   logger.log(WARNING, e, () -> "Syntax error in expression: " + unicode);

--- a/jython/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/loader/Python3Loader.java
+++ b/jython/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/loader/Python3Loader.java
@@ -38,6 +38,7 @@ import java.util.logging.Logger;
 import org.python.core.PyObject;
 import org.python.core.PySyntaxError;
 import org.python.core.PyUnicode;
+import org.python.util.PythonInterpreter;
 
 public class Python3Loader extends PythonLoader {
 
@@ -108,7 +109,7 @@ public class Python3Loader extends PythonLoader {
                 PyUnicode unicode = new PyUnicode(s);
                 PyObject x;
 
-                org.python.util.PythonInterpreter ip = Python3Interpreter.getInterp();
+                PythonInterpreter ip = Python3Interpreter.getInterp();
                 if (ip == null) {
                   // Jython init failed (memoized in Python3Interpreter). Skip constant folding
                   // for this expression; analysis remains correct, just less precise.

--- a/jython/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/util/Python3Interpreter.java
+++ b/jython/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/util/Python3Interpreter.java
@@ -30,10 +30,10 @@ public class Python3Interpreter extends com.ibm.wala.cast.python.util.PythonInte
    * failure. The first failure is already announced by the catch block in {@link #getInterp()};
    * subsequent calls log at FINE level only.
    *
-   * <p>Uses {@link AtomicBoolean#compareAndSet} so the check-and-set is atomic — under concurrent
-   * call graph construction, multiple threads can race into the {@code if (ip == null)} branch
-   * simultaneously, and a non-atomic {@code volatile boolean} flag would let several of them all
-   * pass the check before any sets it, defeating the "log once" intent.
+   * @implNote Uses {@link AtomicBoolean#compareAndSet} so the check-and-set is atomic. Under
+   *     concurrent call graph construction, multiple threads can race into the {@code if (ip ==
+   *     null)} branch simultaneously; a non-atomic {@code volatile boolean} flag would let several
+   *     of them all pass the check before any sets it, defeating the "log once" intent.
    */
   private static final AtomicBoolean unavailableWarned = new AtomicBoolean(false);
 

--- a/jython/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/util/Python3Interpreter.java
+++ b/jython/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/util/Python3Interpreter.java
@@ -53,10 +53,19 @@ public class Python3Interpreter extends com.ibm.wala.cast.python.util.PythonInte
   public Integer evalAsInteger(String expr) {
     PythonInterpreter ip = getInterp();
     if (ip == null) {
-      throw new IllegalStateException(
-          "Jython interpreter unavailable (init failed earlier); cannot evaluate expression: "
-              + expr
-              + ".");
+      // Return {@code null} (the same "cannot evaluate" signal used elsewhere in this method's
+      // contract) rather than throwing, so callers like
+      // {@code com.ibm.wala.cast.python.util.PythonInterpreter#interpretAsInt} — which expect a
+      // nullable {@link Integer} and don't catch checked or runtime exceptions — degrade
+      // gracefully in the same OSGi-classloader environments that triggered the {@link
+      // #getInterp()} init failure in the first place.
+      LOGGER.log(
+          Level.WARNING,
+          () ->
+              "Jython interpreter unavailable (init failed earlier); cannot evaluate expression: "
+                  + expr
+                  + ". Returning null.");
+      return null;
     }
     try {
       PyObject val = ip.eval(expr);

--- a/jython/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/util/Python3Interpreter.java
+++ b/jython/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/util/Python3Interpreter.java
@@ -22,6 +22,15 @@ public class Python3Interpreter extends com.ibm.wala.cast.python.util.PythonInte
    */
   private static volatile boolean initFailed = false;
 
+  /**
+   * Memoizes whether the "interpreter unavailable" warning has already been emitted from {@link
+   * #evalAsInteger(String)}. Without this, callers like {@code interpretAsInt} (invoked many times
+   * during shape inference) would flood logs with one WARNING per call after the first init
+   * failure. The first failure is already announced by the catch block in {@link #getInterp()};
+   * subsequent calls log at FINE level only.
+   */
+  private static volatile boolean unavailableWarned = false;
+
   public static synchronized PythonInterpreter getInterp() {
     if (initFailed) return null;
     if (interp == null) {
@@ -43,7 +52,9 @@ public class Python3Interpreter extends com.ibm.wala.cast.python.util.PythonInte
             Level.WARNING,
             t,
             () ->
-                "Jython interpreter init failed; constant folding will be disabled for this run.");
+                "Jython interpreter init failed; all interpreter-based evaluation will be disabled"
+                    + " for this run (constant folding in Python3Loader, shape-argument"
+                    + " evaluation via interpretAsInt/evalAsInteger, etc.).");
         return null;
       }
     }
@@ -59,12 +70,21 @@ public class Python3Interpreter extends com.ibm.wala.cast.python.util.PythonInte
       // nullable {@link Integer} and don't catch checked or runtime exceptions — degrade
       // gracefully in the same OSGi-classloader environments that triggered the {@link
       // #getInterp()} init failure in the first place.
-      LOGGER.log(
-          Level.WARNING,
-          () ->
-              "Jython interpreter unavailable (init failed earlier); cannot evaluate expression: "
-                  + expr
-                  + ". Returning null.");
+      //
+      // Log the first such call at WARNING (so operators see that some shape inference is being
+      // skipped because of the earlier init failure); subsequent calls log at FINE only, since
+      // the underlying init failure has already been announced from {@link #getInterp()}.
+      if (!unavailableWarned) {
+        unavailableWarned = true;
+        LOGGER.log(
+            Level.WARNING,
+            () ->
+                "Jython interpreter unavailable (init failed earlier); evalAsInteger will return"
+                    + " null for this and any subsequent calls. First skipped expression: "
+                    + expr);
+      } else {
+        LOGGER.log(Level.FINE, () -> "evalAsInteger returning null (interp unavailable): " + expr);
+      }
       return null;
     }
     try {

--- a/jython/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/util/Python3Interpreter.java
+++ b/jython/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/util/Python3Interpreter.java
@@ -22,18 +22,22 @@ public class Python3Interpreter extends com.ibm.wala.cast.python.util.PythonInte
    */
   private static volatile boolean initFailed = false;
 
-  public static PythonInterpreter getInterp() {
+  public static synchronized PythonInterpreter getInterp() {
     if (initFailed) return null;
     if (interp == null) {
       try {
         PySystemState.initialize();
         interp = new PythonInterpreter();
-      } catch (Throwable t) {
+      } catch (Exception t) {
         // Jython init can fail when bootstrap resources (e.g., the embedded
         // _frozen_importlib bytecode used by org.python.core.imp) aren't reachable from the
         // current classloader/working directory. This is environment-dependent (e.g., happens
         // under Tycho-OSGi but not under plain Maven-surefire). Treat as a recoverable failure:
         // log once, memoize, and let callers degrade gracefully.
+        //
+        // We catch {@link Exception} (not {@link Throwable}) so that {@link Error} types
+        // (OOM, stack overflow, linkage errors) keep propagating to the caller — those signal
+        // serious VM problems we don't want to silently swallow and continue past.
         initFailed = true;
         LOGGER.log(
             Level.WARNING,
@@ -47,8 +51,15 @@ public class Python3Interpreter extends com.ibm.wala.cast.python.util.PythonInte
   }
 
   public Integer evalAsInteger(String expr) {
+    PythonInterpreter ip = getInterp();
+    if (ip == null) {
+      throw new IllegalStateException(
+          "Jython interpreter unavailable (init failed earlier); cannot evaluate expression: "
+              + expr
+              + ".");
+    }
     try {
-      PyObject val = getInterp().eval(expr);
+      PyObject val = ip.eval(expr);
       if (val.isInteger()) {
         return val.asInt();
       } else

--- a/jython/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/util/Python3Interpreter.java
+++ b/jython/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/util/Python3Interpreter.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.util;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.python.core.PyException;
@@ -28,8 +29,13 @@ public class Python3Interpreter extends com.ibm.wala.cast.python.util.PythonInte
    * during shape inference) would flood logs with one WARNING per call after the first init
    * failure. The first failure is already announced by the catch block in {@link #getInterp()};
    * subsequent calls log at FINE level only.
+   *
+   * <p>Uses {@link AtomicBoolean#compareAndSet} so the check-and-set is atomic — under concurrent
+   * call graph construction, multiple threads can race into the {@code if (ip == null)} branch
+   * simultaneously, and a non-atomic {@code volatile boolean} flag would let several of them all
+   * pass the check before any sets it, defeating the "log once" intent.
    */
-  private static volatile boolean unavailableWarned = false;
+  private static final AtomicBoolean unavailableWarned = new AtomicBoolean(false);
 
   public static synchronized PythonInterpreter getInterp() {
     if (initFailed) return null;
@@ -74,8 +80,7 @@ public class Python3Interpreter extends com.ibm.wala.cast.python.util.PythonInte
       // Log the first such call at WARNING (so operators see that some shape inference is being
       // skipped because of the earlier init failure); subsequent calls log at FINE only, since
       // the underlying init failure has already been announced from {@link #getInterp()}.
-      if (!unavailableWarned) {
-        unavailableWarned = true;
+      if (unavailableWarned.compareAndSet(false, true)) {
         LOGGER.log(
             Level.WARNING,
             () ->

--- a/jython/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/util/Python3Interpreter.java
+++ b/jython/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/util/Python3Interpreter.java
@@ -13,10 +13,35 @@ public class Python3Interpreter extends com.ibm.wala.cast.python.util.PythonInte
 
   private static PythonInterpreter interp;
 
+  /**
+   * Memoizes a failed Jython init so subsequent {@link #getInterp()} calls return {@code null}
+   * cheaply instead of re-running {@code new PythonInterpreter()} (which can be expensive when it
+   * fails — site-import walks the Jython resource path on every attempt). When a single failure has
+   * occurred, callers receive {@code null} and can degrade their behavior (e.g., {@link
+   * com.ibm.wala.cast.python.loader.Python3Loader} skips constant folding).
+   */
+  private static volatile boolean initFailed = false;
+
   public static PythonInterpreter getInterp() {
+    if (initFailed) return null;
     if (interp == null) {
-      PySystemState.initialize();
-      interp = new PythonInterpreter();
+      try {
+        PySystemState.initialize();
+        interp = new PythonInterpreter();
+      } catch (Throwable t) {
+        // Jython init can fail when bootstrap resources (e.g., the embedded
+        // _frozen_importlib bytecode used by org.python.core.imp) aren't reachable from the
+        // current classloader/working directory. This is environment-dependent (e.g., happens
+        // under Tycho-OSGi but not under plain Maven-surefire). Treat as a recoverable failure:
+        // log once, memoize, and let callers degrade gracefully.
+        initFailed = true;
+        LOGGER.log(
+            Level.WARNING,
+            t,
+            () ->
+                "Jython interpreter init failed; constant folding will be disabled for this run.");
+        return null;
+      }
     }
     return interp;
   }


### PR DESCRIPTION
## Summary

Two-file change to keep module load alive when `new PythonInterpreter()` fails during constant folding. The current `Python3Interpreter.getInterp()` propagates the failure through every recursive `ConstantFoldingRewriter.copyNodes` frame and aborts the entire module load, leaving the class hierarchy with no `.py` entries and `makeDefaultEntrypoints` returning empty.

## Symptom

```
java.io.FileNotFoundException: src/resources/frozen_importlib/_frozen_importlib.class
java.lang.NullPointerException: Cannot invoke "...PyObject.invoke(...)" because "sys.importlib" is null
    at org.python.core.imp.import_next(imp.java:735)
    at org.python.core.Py.importSiteIfSelected(Py.java:1922)
    at org.python.util.PythonInterpreter.<init>(PythonInterpreter.java:114)
    at com.ibm.wala.cast.python.util.Python3Interpreter.getInterp(Python3Interpreter.java:19)
    at com.ibm.wala.cast.python.loader.Python3Loader$4$1.eval(Python3Loader.java:112)
    at com.ibm.wala.cast.ir.translator.ConstantFoldingRewriter.copyNodes(...)
    [... recursive frames ...]
```

The downstream symptom is `IllegalStateException: Could not create a entrypoint callsites:` (with empty `Warnings`) at `PropagationCallGraphBuilder.makeCallGraph:238`, because the failed module load leaves the CHA without any `.py` entries.

## Why It Surfaces Now

Both branches in this commit-pair were silently swallowing the failure prior to a recent change in the [`ponder-lab/ML`](https://github.com/ponder-lab/ML) fork: a `try { ... } catch (Throwable e) {}` block in `getInterp()` was removed, and `PySystemState.initialize()` (previously commented out) was uncommented. Removing the silent swallow exposed an env-dependent Jython bootstrap failure to consumers whose classloader/working-directory setup can't satisfy Jython's `_frozen_importlib` lookup.

## Change

Two coupled edits, ~35 lines total:

- **`Python3Interpreter.getInterp()`** — wrap `new PythonInterpreter()` in try/catch, log once at `WARNING`, memoize the failure via `volatile boolean initFailed`, return `null` instead of throwing. Memoizing matters because const-fold is invoked recursively per AST node; on a module with N const-eligible expressions, retrying the failing constructor each time would be O(N) Jython init attempts.
- **`Python3Loader`'s `ConstantFoldingRewriter.eval` callback** — treat a `null` interpreter as a folding miss (return `null`). Analysis remains correct, just less precise — constant folding is a precision-only feature.

## Validation

`mvn -pl com.ibm.wala.cast.python.ml.test -am test` (with this fix on the ponder-lab fork): 610 tests, 0 failures, 0 errors, 3 skipped. No regression on the existing test surface.

Tycho-OSGi reproducer (Hybridize-Functions-Refactoring `upgrade-tycho-5-java-25` branch consuming a SNAPSHOT with this fix): the 3 `IllegalStateException` failures (`testAutoEncoder`, `testTensorFlowEagerExecution`, `testDatasetIteration4`) no longer surface — const-fold is a no-op for those modules under OSGi but module load proceeds and downstream tensor analysis runs.

## Branch

This branch is rooted at `wala/ML:master` directly (not ponder-lab fork master) so the diff is exactly the two-file change here, with no fork-only commits riding along.