### PR TITLE
Pin WALA submodule to its committed SHA in CI (drop `--remote`)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,8 +15,6 @@ jobs:
       uses: actions/checkout@v5
       with:
         submodules: 'recursive'
-    - name: Update the WALA submodule with its latest commit
-      run: git submodule update --recursive --remote
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:


### PR DESCRIPTION
## Summary

Drops the `git submodule update --recursive --remote` step that overrides `wala/ML`'s committed WALA submodule pointer with `wala/WALA:master` HEAD. Closes [#433](https://github.com/wala/ML/issues/433).

## Why

The committed pointer is `c0e260a62` ("*Prepare next development version*", 2025-09-22) — API-compatible with `wala/ML`'s current code. WALA master moved past that compatibility cliff at [`f08697550`](https://github.com/wala/WALA/commit/f08697550) ("*Record catch types as Set, not array (#1803)*", 2025-12-12), which begins the `AstTranslator` parameter-type refactor that became 1.7.0. Every CI run pulls master and then fails to compile against the now-broken APIs.

The committed pointer is fine; CI just needs to honor it instead of `--remote`-ing past it.

## Change

```diff
     - name: Check out wala/ML sources
       uses: actions/checkout@v5
       with:
         submodules: 'recursive'
-    - name: Update the WALA submodule with its latest commit
-      run: git submodule update --recursive --remote
     - name: Set up JDK
```

`actions/checkout` with `submodules: 'recursive'` already initializes the submodule at the committed pointer. To intentionally take in new WALA changes, run `git submodule update --remote` locally and commit the new pointer.

## Validation

- The committed submodule pointer (`c0e260a62`) compiles cleanly against `wala/ML`'s current code.
- I confirmed `mvn -pl ml/com.ibm.wala.cast.python.ml.test -am test` (after `./gradlew build publishToMavenLocal` on WALA at `c0e260a62`) runs the full ML test suite without the runtime failures we'd see against `1.6.12` proper.

## Cross-Refs

- [#433](https://github.com/wala/ML/issues/433) — root issue (closed by this PR).
- [`wala/WALA#1896`](https://github.com/wala/WALA/issues/1896) — request to tag `4eb96214e` as `v1.6.13`. If accepted, a follow-up PR can move `<wala.version>` to that release and remove the submodule entirely.
- [#440](https://github.com/wala/ML/issues/440), [#441](https://github.com/wala/ML/issues/441) — JEP migration tracker (the durable answer; long-term endpoint is removing the WALA submodule entirely).