### PR TITLE
Drop dead `logging.properties` include from `jython3.test` POM (#493 follow-up)

### DIFF
--- a/jython/com.ibm.wala.cast.python.jython3.test/pom.xml
+++ b/jython/com.ibm.wala.cast.python.jython3.test/pom.xml
@@ -43,7 +43,6 @@
         <includes>
           <include>META-INF/**</include>
           <include>build.properties</include>
-          <include>logging.properties</include>
         </includes>
       </resource>
     </resources>


### PR DESCRIPTION
## Summary

- Removes the `<include>logging.properties</include>` line that #493 added to `jython/com.ibm.wala.cast.python.jython3.test/pom.xml`.
- The line packages `jython/com.ibm.wala.cast.python.jython3.test/logging.properties`, which is a symlink to `../logging.properties` (resolves to a sibling file from the module dir).
- Maven copies the *symlink* (not its target) into `target/classes/logging.properties`. The relative target `../logging.properties` then points at `target/logging.properties`, which doesn't exist — so the packaged resource is unreadable at runtime.
- Mirror of ponder-lab/ML#272.

Closes #502.

## Verification

```
$ ls -L jython/com.ibm.wala.cast.python.jython3.test/target/classes/logging.properties
ls: cannot access '...': No such file or directory
```

(After `mvn clean install -DskipTests`, the symlink is in `target/classes/` but its readlink target doesn't exist.)

## Test Plan

- [x] No Java/Python touched; CI catches anything genuinely broken.
- [x] `target/classes/logging.properties` no longer materializes after this change (Maven simply skips the resource).
- [x] Dev-time `mvn -pl ... test` still resolves `logging.properties` via the module-dir symlink — Surefire reads from the source tree, not `target/classes/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)